### PR TITLE
[milvus] Add podLabels option for attu.

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.2.13"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.0.31
+version: 4.0.32
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/attu-deployment.yaml
+++ b/charts/milvus/templates/attu-deployment.yaml
@@ -17,6 +17,9 @@ spec:
       labels:
 {{ include "milvus.matchLabels" . | indent 8 }}
         component: "attu"
+{{- if .Values.attu.podLabels }}
+{{ toYaml .Values.attu.podLabels | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.attu.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -408,6 +408,7 @@ attu:
     port: 3000
     # loadBalancerIP: ""
   resources: {}
+  podLabels: {}
   ingress:
     enabled: false
     annotations: {}


### PR DESCRIPTION
## What this PR does / why we need it:
This adds pod labels to pods created as part of the attu deployment.

## Checklist
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
