### PR TITLE
[milvus] Fix key of config for zookeeper's PDB

### DIFF
--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -619,7 +619,7 @@ pulsar:
          -XX:+PerfDisableSharedMem
          -Dzookeeper.forceSync=no
     pdb:
-      usePolicy: false
+      create: false
 
   bookkeeper:
     replicaCount: 3


### PR DESCRIPTION
## What this PR does / why we need it:
The config name whether creating PDB for zookeeper of not is incorrect.
https://github.com/bitnami/charts/blob/51dac1ef2e068e1f357fdfa0c8e7e4142dd2d4e7/bitnami/zookeeper/templates/pdb.yaml#L7

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
