### PR TITLE
[milvus] allow to unset replicas field in autoscalable deployments

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.3.1"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.1.4
+version: 4.1.5
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -12,7 +12,9 @@ metadata:
 {{ include "milvus.ud.annotations" . | indent 4 }}
 
 spec:
+  {{- if ge (int .Values.dataNode.replicas) 0 }}
   replicas: {{ .Values.dataNode.replicas }}
+  {{- end }}
   selector:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -11,7 +11,9 @@ metadata:
 {{ include "milvus.ud.annotations" . | indent 4 }}
 
 spec:
+  {{- if ge (int .Values.indexNode.replicas) 0 }}
   replicas: {{ .Values.indexNode.replicas }}
+  {{- end }}
   selector:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -12,7 +12,9 @@ metadata:
 {{ include "milvus.ud.annotations" . | indent 4 }}
 
 spec:
+  {{- if ge (int .Values.proxy.replicas) 0 }}
   replicas: {{ .Values.proxy.replicas }}
+  {{- end }}
   selector:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -11,7 +11,9 @@ metadata:
 {{ include "milvus.ud.annotations" . | indent 4 }}
 
 spec:
+  {{- if ge (int .Values.queryNode.replicas) 0 }}
   replicas: {{ .Values.queryNode.replicas }}
+  {{- end }}
   selector:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -215,6 +215,7 @@ standalone:
 
 proxy:
   enabled: true
+  # You can set the number of replicas to -1 to remove the replicas field in case you want to use HPA
   replicas: 1
   resources: {}
   nodeSelector: {}
@@ -276,6 +277,7 @@ queryCoordinator:
 
 queryNode:
   enabled: true
+  # You can set the number of replicas to -1 to remove the replicas field in case you want to use HPA
   replicas: 1
   resources: {}
   # Set local storage size in resources
@@ -318,6 +320,7 @@ indexCoordinator:
 
 indexNode:
   enabled: true
+  # You can set the number of replicas to -1 to remove the replicas field in case you want to use HPA
   replicas: 1
   resources: {}
   # Set local storage size in resources
@@ -360,6 +363,7 @@ dataCoordinator:
 
 dataNode:
   enabled: true
+  # You can set the number of replicas to -1 to remove the replicas field in case you want to use HPA
   replicas: 1
   resources: {}
   nodeSelector: {}


### PR DESCRIPTION
## What this PR does / why we need it:

Hi !

If users configure HPA on their side to control index/data/query/proxy pods Deployments, we need to remove the replicas field to avoid the bad well-known HPA behavior in case of rollout-update/apply.

https://github.com/kubernetes/kubernetes/issues/25238

This feature will be necessary when HPA will be available in this chart again as well :)

Fix [#16](https://github.com/zilliztech/milvus-helm/issues/16)

Regards,

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
