### PR TITLE
[Milvus] Add labels to attu component

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: milvus
-appVersion: "2.3.2"
+appVersion: "2.3.1"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
 version: 4.1.3

--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: milvus
-appVersion: "2.3.0"
+appVersion: "2.3.2"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.1.2
+version: 4.1.3
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.3.0"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.1.1
+version: 4.1.2
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/attu-deployment.yaml
+++ b/charts/milvus/templates/attu-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "attu"
+{{ include "milvus.ud.labels" . | indent 4 }}
 spec:
   replicas: 1
   selector:
@@ -17,6 +18,7 @@ spec:
       labels:
 {{ include "milvus.matchLabels" . | indent 8 }}
         component: "attu"
+{{ include "milvus.ud.labels" . | indent 8 }}
 {{- if .Values.attu.podLabels }}
 {{ toYaml .Values.attu.podLabels | indent 8 }}
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:
The labels specified in the global values section are currently not being applied to the Attu deployment. This modification will ensure that the labels defined by users are incorporated into the Attu deployment

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
