### PR TITLE
[Milvus] Add nodeSelector to Attu deployment

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.3.1"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.1.3
+version: 4.1.4
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/attu-deployment.yaml
+++ b/charts/milvus/templates/attu-deployment.yaml
@@ -57,4 +57,12 @@ spec:
       tolerations:
 {{ toYaml .Values.attu.tolerations | indent 8 }}
     {{- end }}
+{{- if and (.Values.nodeSelector) (not .Values.attu.nodeSelector) }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+   {{- end }}
+   {{- if .Values.attu.nodeSelector }}
+      nodeSelector:
+   {{ toYaml .Values.attu.nodeSelector | indent 8 }}
+   {{- end }}
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:
Include nodeSelectors in the Attu deployment to limit pod scheduling to specific dedicated nodes.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
