### PR TITLE
[milvus] <fix>: Add child Chart MinIO configuration to Milvus level

### DIFF
--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -476,6 +476,13 @@ minio:
     requests:
       memory: 2Gi
 
+  tls:
+    enabled: false
+    ## Create a secret with private.key and public.crt files and pass that here. Ref: https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
+    certSecret: ""
+    publicCrt: public.crt
+    privateKey: private.key
+
   gcsgateway:
     enabled: false
     replicas: 1


### PR DESCRIPTION
## What this PR does / why we need it:
1. If we don't add it, helm will report an error when minio is disabled. For the specific reason, see template/config.tpl:59
2. If not all of ths tls configs are raised (i.e just add tls: enable to the parent chart values), when the user enables tls, he needs to add Key/Cert to the sub-Chart. Therefore, all TLS-related configurations are brought up to Milvus Chart Values.
## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
