### PR TITLE
[Milvus] <readme>: update minio readme reference link in milvus value file

### DIFF
--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -451,7 +451,7 @@ attu:
 
 
 ## Configuration values for the minio dependency
-## ref: https://github.com/minio/charts/blob/master/README.md
+## ref: https://github.com/zilliztech/milvus-helm/blob/master/charts/minio/README.md
 ##
 
 minio:


### PR DESCRIPTION
## What this PR does / why we need it:

Removes and updates the wrong minIO readme reference link in Milvus value file 

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
