### PR TITLE
[milvus] add Deployment strategy configuration

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.3.10"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.1.20
+version: 4.1.21
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -353,6 +353,7 @@ The following table lists the configurable parameters of the Milvus Proxy compon
 | `proxy.http.enabled`                      | Enable rest api for Milvus Proxy | `true`                                          |
 | `proxy.http.debugMode.enabled`            | Enable debug mode for rest api | `false`                                          |
 | `proxy.tls.enabled`                       | Enable porxy tls connection | `false`                                          |
+| `proxy.strategy`                          | Deployment strategy configuration |  RollingUpdate                                         |
 
 ### Milvus Root Coordinator Deployment Configuration
 
@@ -418,6 +419,7 @@ The following table lists the configurable parameters of the Milvus Query Node c
 | `queryNode.disk.enabled`                  | Whether to enable disk for query                             | `true`                                          |
 | `queryNode.profiling.enabled`             | Whether to enable live profiling                   | `false`                                          |
 | `queryNode.extraEnv`                      | Additional Milvus Query Node container environment variables | `[]`                                     |
+| `queryNode.strategy`                      | Deployment strategy configuration |  RollingUpdate                                         |
 
 ### Milvus Index Coordinator Deployment Configuration
 
@@ -459,6 +461,7 @@ The following table lists the configurable parameters of the Milvus Index Node c
 | `indexNode.disk.enabled`                  | Whether to enable disk for index node                             | `true`                                          |
 | `indexNode.profiling.enabled`             | Whether to enable live profiling                   | `false`                                          |
 | `indexNode.extraEnv`                      | Additional Milvus Index Node container environment variables | `[]`                                     |
+| `indexNode.strategy`                      | Deployment strategy configuration |  RollingUpdate                                         |
 
 ### Milvus Data Coordinator Deployment Configuration
 
@@ -499,6 +502,7 @@ The following table lists the configurable parameters of the Milvus Data Node co
 | `dataNode.heaptrack.enabled`              | Whether to enable heaptrack                             | `false`                                          |
 | `dataNode.profiling.enabled`              | Whether to enable live profiling                   | `false`                                          |
 | `dataNode.extraEnv`                       | Additional Milvus Data Node container environment variables | `[]`                                      |
+| `dataNode.strategy`                       | Deployment strategy configuration |  RollingUpdate                                         |
 
 ### Milvus Mixture Coordinator Deployment Configuration
 

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -15,6 +15,10 @@ spec:
   {{- if ge (int .Values.dataNode.replicas) 0 }}
   replicas: {{ .Values.dataNode.replicas }}
   {{- end }}
+  {{- with .Values.dataNode.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -14,6 +14,10 @@ spec:
   {{- if ge (int .Values.indexNode.replicas) 0 }}
   replicas: {{ .Values.indexNode.replicas }}
   {{- end }}
+  {{- with .Values.indexNode.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -15,6 +15,10 @@ spec:
   {{- if ge (int .Values.proxy.replicas) 0 }}
   replicas: {{ .Values.proxy.replicas }}
   {{- end }}
+  {{- with .Values.proxy.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -14,6 +14,10 @@ spec:
   {{- if ge (int .Values.queryNode.replicas) 0 }}
   replicas: {{ .Values.queryNode.replicas }}
   {{- end }}
+  {{- with .Values.queryNode.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -253,6 +253,9 @@ proxy:
 #  volumeMounts:
 #  - mountPath: /etc/milvus/certs/
 #    name: milvus-tls
+  # Deployment strategy, default is RollingUpdate
+  # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
+  strategy: {}
 
 rootCoordinator:
   enabled: true
@@ -318,6 +321,9 @@ queryNode:
       enabled: false  # Enable local storage size limit
   profiling:
     enabled: false  # Enable live profiling
+  # Deployment strategy, default is RollingUpdate
+  # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
+  strategy: {}
 
 indexCoordinator:
   enabled: true
@@ -361,6 +367,9 @@ indexNode:
     enabled: true  # Enable index node build disk vector index
     size:
       enabled: false  # Enable local storage size limit
+  # Deployment strategy, default is RollingUpdate
+  # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
+  strategy: {}
 
 dataCoordinator:
   enabled: true
@@ -397,6 +406,9 @@ dataNode:
     enabled: false
   profiling:
     enabled: false  # Enable live profiling
+  # Deployment strategy, default is RollingUpdate
+  # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
+  strategy: {}
 
 ## mixCoordinator contains all coord
 ## If you want to use mixcoord, enable this and disable all of other coords 


### PR DESCRIPTION
## What this PR does / why we need it:
Allow to specify the Deployment' strategy for "node" components (indexNode, queryNode, dataNode, proxyNode).
Usefull when you want more control on the RollingUpdate process (maxUnavailable, maxSurge...).


## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
