### PR TITLE
Draft: Add resources configuration to initcontainers

### DIFF
--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -50,6 +50,8 @@ spec:
         - "cp -r /opt/heaptrack /milvus/tools"
         image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        resources:
+          {{- toYaml .Values.dataNode.init.heaptrack.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
@@ -61,6 +63,8 @@ spec:
         - /milvus/tools/run-helm.sh,/milvus/tools/merge
         image: "{{ .Values.image.tools.repository }}:{{ .Values.image.tools.tag }}"
         imagePullPolicy: {{ .Values.image.tools.pullPolicy}}
+        resources:
+          {{- toYaml .Values.dataNode.init.config.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools


### PR DESCRIPTION
## What this PR does / why we need it:
Allow to deploy that chart on Kube clusters which force to have resources configuration for every pods (even initContainers)

## Checklist
- [ ] Add ressources to other components
- [ ] Update values
- [ ] Update doc