### PR TITLE
[milvus-4.1.18] Enhancement: Reset Default Max Limit on Users per Milvus Instance

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.3.10"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.1.20
+version: 4.1.21
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: milvus
-appVersion: "2.3.9"
+appVersion: "2.3.10"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.1.18
+version: 4.1.22
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -239,7 +239,7 @@ The following table lists the configurable parameters of the Milvus Service and 
 |-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
 | `cluster.enabled`                         | Enable or disable Milvus Cluster mode         | `true`                                                 |
 | `image.all.repository`                    | Image repository                              | `milvusdb/milvus`                                       |
-| `image.all.tag`                           | Image tag                                     | `v2.3.9`                           |
+| `image.all.tag`                           | Image tag                                     | `v2.3.10`                           |
 | `image.all.pullPolicy`                    | Image pull policy                             | `IfNotPresent`                                          |
 | `image.all.pullSecrets`                   | Image pull secrets                            | `{}`                                                    |
 | `image.tools.repository`                  | Config image repository                       | `milvusdb/milvus-config-tool`                                       |

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -5,7 +5,7 @@ cluster:
 image:
   all:
     repository: milvusdb/milvus
-    tag: v2.3.9
+    tag: v2.3.10
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -50,6 +50,7 @@ extraConfigFiles:
     #    proxy:
     #      http:
     #        enabled: true
+    #      maxUserNum: 100
     ##  Enable tlsMode and set the tls cert and key
     #  tls:
     #    serverPemPath: /etc/milvus/certs/tls.crt


### PR DESCRIPTION
Author - @Rachit-Chaudhary11

## What this PR does / why we need it:
This update will allow for better scalability and flexibility in managing the users access to milvus instance. Presently this limit is set to 100 users per milvus instance and there is no way to increase / decrease the users limit to milvus instance.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
