### PR TITLE
[milvus-4.1.18] Adding support for ScaNN index 

### DIFF
--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -426,7 +426,7 @@ attu:
   name: attu
   image:
     repository: zilliz/attu
-    tag: v2.2.8
+    tag: v2.3.0
     pullPolicy: IfNotPresent
   service:
     annotations: {}


### PR DESCRIPTION
## What this PR does / why we need it:
In order to ensure proper coordination and support for Scann index we need this fix. A new Scann index is essential for enhancing performance, scalability, customisation and competitiveness which is missing in older version of attu.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
