### PR TITLE
Enhancement: Configurable User Role limit for Milvus

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.3.10"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.1.22
+version: 4.1.23
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -339,21 +339,23 @@ The following table lists the configurable parameters of the Milvus Standalone c
 
 The following table lists the configurable parameters of the Milvus Proxy component and their default values.
 
-| Parameter                                 | Description                                   | Default                                                 |
-|-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
-| `proxy.enabled`                           | Enable or disable Milvus Proxy Deployment     | `true`                                                  |
-| `proxy.replicas`                          | Desired number of Milvus Proxy pods            | `1`                                                    |
-| `proxy.resources`                         | Resource requests/limits for the Milvus Proxy pods | `{}`                                               |
-| `proxy.nodeSelector`                      | Node labels for Milvus Proxy pods assignment | `{}`                                                     |
-| `proxy.affinity`                          | Affinity settings for Milvus Proxy pods assignment | `{}`                                               |
-| `proxy.tolerations`                       | Toleration labels for Milvus Proxy pods assignment | `[]`                                               |
-| `proxy.heaptrack.enabled`                 | Whether to enable heaptrack                             | `false`                                          |
-| `proxy.profiling.enabled`                 | Whether to enable live profiling                   | `false`                                          |
-| `proxy.extraEnv`                          | Additional Milvus Proxy container environment variables | `[]`                                          |
-| `proxy.http.enabled`                      | Enable rest api for Milvus Proxy | `true`                                          |
-| `proxy.http.debugMode.enabled`            | Enable debug mode for rest api | `false`                                          |
-| `proxy.tls.enabled`                       | Enable porxy tls connection | `false`                                          |
-| `proxy.strategy`                          | Deployment strategy configuration |  RollingUpdate                                         |
+| Parameter                                 | Description                                             | Default       |
+|-------------------------------------------|---------------------------------------------------------|---------------|
+| `proxy.enabled`                           | Enable or disable Milvus Proxy Deployment               | `true`        |
+| `proxy.replicas`                          | Desired number of Milvus Proxy pods                     | `1`           |
+| `proxy.resources`                         | Resource requests/limits for the Milvus Proxy pods      | `{}`          |
+| `proxy.nodeSelector`                      | Node labels for Milvus Proxy pods assignment            | `{}`          |
+| `proxy.affinity`                          | Affinity settings for Milvus Proxy pods assignment      | `{}`          |
+| `proxy.tolerations`                       | Toleration labels for Milvus Proxy pods assignment      | `[]`          |
+| `proxy.heaptrack.enabled`                 | Whether to enable heaptrack                             | `false`       |
+| `proxy.profiling.enabled`                 | Whether to enable live profiling                        | `false`       |
+| `proxy.extraEnv`                          | Additional Milvus Proxy container environment variables | `[]`          |
+| `proxy.http.enabled`                      | Enable rest api for Milvus Proxy                        | `true`        |
+| `proxy.maxUserNum`                       | Modify the Milvus maximum user limit                    | `100`         |
+| `proxy.maxRoleNum`                       | Modify the Milvus maximum role limit                    | `10`          |
+| `proxy.http.debugMode.enabled`            | Enable debug mode for rest api                          | `false`       |
+| `proxy.tls.enabled`                       | Enable porxy tls connection                             | `false`       |
+| `proxy.strategy`                          | Deployment strategy configuration                       | RollingUpdate |
 
 ### Milvus Root Coordinator Deployment Configuration
 

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -51,6 +51,7 @@ extraConfigFiles:
     #      http:
     #        enabled: true
     #      maxUserNum: 100
+    #      maxRoleNum: 10
     ##  Enable tlsMode and set the tls cert and key
     #  tls:
     #    serverPemPath: /etc/milvus/certs/tls.crt


### PR DESCRIPTION
## What this PR does / why we need it:
This enhancement empowers administrators to dynamically adjust the maximum number of roles allowed within the system, providing greater flexibility and adaptability to varying organisational structures and evolving access control needs

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
