### PR TITLE
add namespace metadata

### DIFF
--- a/charts/milvus/templates/attu-deployment.yaml
+++ b/charts/milvus/templates/attu-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.attu.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "attu"

--- a/charts/milvus/templates/attu-deployment.yaml
+++ b/charts/milvus/templates/attu-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.attu.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "attu"

--- a/charts/milvus/templates/attu-ingress.yaml
+++ b/charts/milvus/templates/attu-ingress.yaml
@@ -7,7 +7,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "milvus.attu.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.attu.ingress.labels }}
@@ -57,6 +57,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "milvus.attu.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.attu.ingress.labels }}

--- a/charts/milvus/templates/attu-ingress.yaml
+++ b/charts/milvus/templates/attu-ingress.yaml
@@ -7,6 +7,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "milvus.attu.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.attu.ingress.labels }}

--- a/charts/milvus/templates/attu-svc.yaml
+++ b/charts/milvus/templates/attu-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.attu.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.attu.service.labels }}

--- a/charts/milvus/templates/attu-svc.yaml
+++ b/charts/milvus/templates/attu-svc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.attu.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.attu.service.labels }}

--- a/charts/milvus/templates/configmap.yaml
+++ b/charts/milvus/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "milvus.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
 data:
   default.yaml: |+
     {{- include "milvus.config" . | nindent 4 }}

--- a/charts/milvus/templates/configmap.yaml
+++ b/charts/milvus/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "milvus.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
 data:
   default.yaml: |+
     {{- include "milvus.config" . | nindent 4 }}

--- a/charts/milvus/templates/datacoord-deployment.yaml
+++ b/charts/milvus/templates/datacoord-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.datacoord.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "datacoord"

--- a/charts/milvus/templates/datacoord-deployment.yaml
+++ b/charts/milvus/templates/datacoord-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.datacoord.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "datacoord"

--- a/charts/milvus/templates/datacoord-svc.yaml
+++ b/charts/milvus/templates/datacoord-svc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.datacoord.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.dataCoordinator.service.labels }}

--- a/charts/milvus/templates/datacoord-svc.yaml
+++ b/charts/milvus/templates/datacoord-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.datacoord.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.dataCoordinator.service.labels }}

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.datanode.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "datanode"

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.datanode.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "datanode"

--- a/charts/milvus/templates/datanode-svc.yaml
+++ b/charts/milvus/templates/datanode-svc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.datanode.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "datanode"

--- a/charts/milvus/templates/datanode-svc.yaml
+++ b/charts/milvus/templates/datanode-svc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.datanode.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "datanode"

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.indexcoord.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "indexcoord"

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.indexcoord.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "indexcoord"

--- a/charts/milvus/templates/indexcoord-svc.yaml
+++ b/charts/milvus/templates/indexcoord-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.indexcoord.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.indexCoordinator.service.labels }}

--- a/charts/milvus/templates/indexcoord-svc.yaml
+++ b/charts/milvus/templates/indexcoord-svc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.indexcoord.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.indexCoordinator.service.labels }}

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.indexnode.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "indexnode"

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.indexnode.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "indexnode"

--- a/charts/milvus/templates/indexnode-svc.yaml
+++ b/charts/milvus/templates/indexnode-svc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.indexnode.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "indexnode"

--- a/charts/milvus/templates/indexnode-svc.yaml
+++ b/charts/milvus/templates/indexnode-svc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.indexnode.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "indexnode"

--- a/charts/milvus/templates/ingress.yaml
+++ b/charts/milvus/templates/ingress.yaml
@@ -7,6 +7,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "milvus.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.ingress.labels }}
@@ -54,6 +55,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "milvus.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.ingress.labels }}

--- a/charts/milvus/templates/ingress.yaml
+++ b/charts/milvus/templates/ingress.yaml
@@ -7,7 +7,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "milvus.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.ingress.labels }}
@@ -55,7 +55,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "milvus.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.ingress.labels }}

--- a/charts/milvus/templates/mixcoord-deployment.yaml
+++ b/charts/milvus/templates/mixcoord-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.mixcoord.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "mixcoord"

--- a/charts/milvus/templates/mixcoord-deployment.yaml
+++ b/charts/milvus/templates/mixcoord-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.mixcoord.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "mixcoord"

--- a/charts/milvus/templates/mixcoord-svc.yaml
+++ b/charts/milvus/templates/mixcoord-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.mixcoord.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.mixCoordinator.service.labels }}

--- a/charts/milvus/templates/mixcoord-svc.yaml
+++ b/charts/milvus/templates/mixcoord-svc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.mixcoord.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.mixCoordinator.service.labels }}

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.proxy.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "proxy"

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.proxy.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "proxy"

--- a/charts/milvus/templates/proxy-tls-secret.yaml
+++ b/charts/milvus/templates/proxy-tls-secret.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.proxy.tls.secretName }}
+  namespace: {{ .Release.Namespace | quote }}
 data:
   tls.crt: {{ .Values.proxy.tls.crt }}
   tls.key: {{ .Values.proxy.tls.key }}

--- a/charts/milvus/templates/proxy-tls-secret.yaml
+++ b/charts/milvus/templates/proxy-tls-secret.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.proxy.tls.secretName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
 data:
   tls.crt: {{ .Values.proxy.tls.crt }}
   tls.key: {{ .Values.proxy.tls.key }}

--- a/charts/milvus/templates/pulsar-podmonitor.yaml
+++ b/charts/milvus/templates/pulsar-podmonitor.yaml
@@ -5,6 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "milvus.pulsar.fullname" . }}-broker
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: pulsar
     cluster: {{ template "milvus.pulsar.fullname" .}}
@@ -31,6 +32,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "milvus.pulsar.fullname" . }}-proxy
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: pulsar
     cluster: {{ template "milvus.pulsar.fullname" .}}

--- a/charts/milvus/templates/pulsar-podmonitor.yaml
+++ b/charts/milvus/templates/pulsar-podmonitor.yaml
@@ -5,7 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "milvus.pulsar.fullname" . }}-broker
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pulsar
     cluster: {{ template "milvus.pulsar.fullname" .}}
@@ -32,7 +32,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "milvus.pulsar.fullname" . }}-proxy
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pulsar
     cluster: {{ template "milvus.pulsar.fullname" .}}

--- a/charts/milvus/templates/pvc.yaml
+++ b/charts/milvus/templates/pvc.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ printf "%s" (include "milvus.fullname" . | trunc 58)}}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
 {{- with .Values.standalone.persistence.annotations  }}
   annotations:
 {{ toYaml . | indent 4 }}
@@ -37,7 +37,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ printf "%s-logs" (include "milvus.fullname" . | trunc 58)}}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
 {{- with .Values.log.persistence.annotations  }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/milvus/templates/pvc.yaml
+++ b/charts/milvus/templates/pvc.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ printf "%s" (include "milvus.fullname" . | trunc 58)}}
+  namespace: {{ .Release.Namespace | quote }}
 {{- with .Values.standalone.persistence.annotations  }}
   annotations:
 {{ toYaml . | indent 4 }}
@@ -36,6 +37,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ printf "%s-logs" (include "milvus.fullname" . | trunc 58)}}
+  namespace: {{ .Release.Namespace | quote }}
 {{- with .Values.log.persistence.annotations  }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/milvus/templates/querycoord-deployment.yaml
+++ b/charts/milvus/templates/querycoord-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.querycoord.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "querycoord"

--- a/charts/milvus/templates/querycoord-deployment.yaml
+++ b/charts/milvus/templates/querycoord-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.querycoord.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "querycoord"

--- a/charts/milvus/templates/querycoord-svc.yaml
+++ b/charts/milvus/templates/querycoord-svc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.querycoord.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.queryCoordinator.service.labels }}

--- a/charts/milvus/templates/querycoord-svc.yaml
+++ b/charts/milvus/templates/querycoord-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.querycoord.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.queryCoordinator.service.labels }}

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.querynode.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "querynode"

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.querynode.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "querynode"

--- a/charts/milvus/templates/querynode-svc.yaml
+++ b/charts/milvus/templates/querynode-svc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.querynode.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "querynode"

--- a/charts/milvus/templates/querynode-svc.yaml
+++ b/charts/milvus/templates/querynode-svc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.querynode.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "querynode"

--- a/charts/milvus/templates/rootcoord-deployment.yaml
+++ b/charts/milvus/templates/rootcoord-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.rootcoord.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "rootcoord"

--- a/charts/milvus/templates/rootcoord-deployment.yaml
+++ b/charts/milvus/templates/rootcoord-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.rootcoord.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "rootcoord"

--- a/charts/milvus/templates/rootcoord-svc.yaml
+++ b/charts/milvus/templates/rootcoord-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.rootcoord.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.rootCoordinator.service.labels }}

--- a/charts/milvus/templates/rootcoord-svc.yaml
+++ b/charts/milvus/templates/rootcoord-svc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.rootcoord.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.rootCoordinator.service.labels }}

--- a/charts/milvus/templates/service.yaml
+++ b/charts/milvus/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.service.labels }}

--- a/charts/milvus/templates/service.yaml
+++ b/charts/milvus/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "milvus.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
 {{- if .Values.service.labels }}

--- a/charts/milvus/templates/serviceaccount.yaml
+++ b/charts/milvus/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "milvus.serviceAccount" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}

--- a/charts/milvus/templates/serviceaccount.yaml
+++ b/charts/milvus/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "milvus.serviceAccount" . }}
+  namespace: {{ .Release.Namespace | quote }}
 {{- if .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}

--- a/charts/milvus/templates/servicemonitor.yaml
+++ b/charts/milvus/templates/servicemonitor.yaml
@@ -5,7 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "milvus.standalone.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
@@ -38,7 +38,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "milvus.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}

--- a/charts/milvus/templates/servicemonitor.yaml
+++ b/charts/milvus/templates/servicemonitor.yaml
@@ -5,6 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "milvus.standalone.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
@@ -37,6 +38,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "milvus.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}

--- a/charts/milvus/templates/standalone-deployment.yaml
+++ b/charts/milvus/templates/standalone-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.standalone.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "standalone"

--- a/charts/milvus/templates/standalone-deployment.yaml
+++ b/charts/milvus/templates/standalone-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "milvus.standalone.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "standalone"

--- a/charts/minio/templates/configmap.yaml
+++ b/charts/minio/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}

--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -8,6 +8,7 @@ apiVersion: {{ template "minio.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}

--- a/charts/minio/templates/ingress.yaml
+++ b/charts/minio/templates/ingress.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ template "minio.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}

--- a/charts/minio/templates/networkpolicy.yaml
+++ b/charts/minio/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ kind: NetworkPolicy
 apiVersion: {{ template "minio.networkPolicy.apiVersion" . }}
 metadata:
   name: {{ template "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}

--- a/charts/minio/templates/poddisruptionbudget.yaml
+++ b/charts/minio/templates/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ template "minio.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: minio
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}
 spec:

--- a/charts/minio/templates/podmonitor.yaml
+++ b/charts/minio/templates/podmonitor.yaml
@@ -7,6 +7,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}
     release: {{ .Release.Name }}

--- a/charts/minio/templates/post-install-create-bucket-job.yaml
+++ b/charts/minio/templates/post-install-create-bucket-job.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "minio.fullname" . }}-make-bucket-job
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}-make-bucket-job
     chart: {{ template "minio.chart" . }}

--- a/charts/minio/templates/post-install-prometheus-metrics-job.yaml
+++ b/charts/minio/templates/post-install-prometheus-metrics-job.yaml
@@ -8,6 +8,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ $fullName }}-update-prometheus-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}-update-prometheus-secret
     chart: {{ template "minio.chart" . }}

--- a/charts/minio/templates/post-install-prometheus-metrics-role.yaml
+++ b/charts/minio/templates/post-install-prometheus-metrics-role.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $fullName }}-update-prometheus-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}-update-prometheus-secret
     chart: {{ template "minio.chart" . }}

--- a/charts/minio/templates/post-install-prometheus-metrics-rolebinding.yaml
+++ b/charts/minio/templates/post-install-prometheus-metrics-rolebinding.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $fullName }}-update-prometheus-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}-update-prometheus-secret
     chart: {{ template "minio.chart" . }}

--- a/charts/minio/templates/post-install-prometheus-metrics-serviceaccount.yaml
+++ b/charts/minio/templates/post-install-prometheus-metrics-serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $fullName }}-update-prometheus-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}-update-prometheus-secret
     chart: {{ template "minio.chart" . }}

--- a/charts/minio/templates/pvc.yaml
+++ b/charts/minio/templates/pvc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.persistence.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/minio/templates/secrets.yaml
+++ b/charts/minio/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "minio.secretName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}

--- a/charts/minio/templates/securitycontextconstraints.yaml
+++ b/charts/minio/templates/securitycontextconstraints.yaml
@@ -3,6 +3,7 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   name: {{ template "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}

--- a/charts/minio/templates/service.yaml
+++ b/charts/minio/templates/service.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}

--- a/charts/minio/templates/statefulset.yaml
+++ b/charts/minio/templates/statefulset.yaml
@@ -17,6 +17,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "minio.fullname" . }}-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}
@@ -37,6 +38,7 @@ apiVersion: {{ template "minio.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
   name: {{ template "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}


### PR DESCRIPTION
## What this PR does / why we need it:

`metadata.namespace` is missing in some templates.

this is needed for when helm is used purely as a templating tool,
since helm template does not add the namespace
https://github.com/helm/helm/issues/3553

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
