### PR TITLE
[milvus] Ability to use user specified ConfigMap for Milvus configuration

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.4.5"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.1.34
+version: 4.1.35
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -214,7 +214,7 @@ In case you want to use a different `secretName` or mount path inside pod, modif
 
 ## Milvus with External Object Storage
 
-As of https://github.com/minio/minio/releases/tag/RELEASE.2022-10-29T06-21-33Z, the MinIO Gateway and the related filesystem mode code have been removed. It is now recommended to utilize the `externalS3` configuration for integrating with various object storage services. Notably, Milvus now provides support for popular object storage platforms such as AWS S3, GCP GCS, Azure Blob, Aliyun OSS and Tencent COS. 
+As of https://github.com/minio/minio/releases/tag/RELEASE.2022-10-29T06-21-33Z, the MinIO Gateway and the related filesystem mode code have been removed. It is now recommended to utilize the `externalS3` configuration for integrating with various object storage services. Notably, Milvus now provides support for popular object storage platforms such as AWS S3, GCP GCS, Azure Blob, Aliyun OSS and Tencent COS.
 
 The recommended configuration option for `externalS3.cloudProvider` includes the following choices: `aws`, `gcp`, `azure`, `aliyun`, and `tencent`. Here's an example to use AWS S3 for Milvus object storage:
 
@@ -266,6 +266,7 @@ The following table lists the configurable parameters of the Milvus Service and 
 | `image.tools.repository`                  | Config image repository                       | `milvusdb/milvus-config-tool`                                       |
 | `image.tools.tag`                         | Config image tag                              | `v0.1.2`                           |
 | `image.tools.pullPolicy`                  | Config image pull policy                      | `IfNotPresent`                                          |
+| `customConfigMap`                         | User specified ConfigMap for configuration    |
 | `extraConfigFiles`                        | Extra config to override default milvus.yaml  | `user.yaml:`                                                     |
 | `service.type`                            | Service type                                  | `ClusterIP`                                             |
 | `service.port`                            | Port where service is exposed                 | `19530`                                                 |

--- a/charts/milvus/templates/configmap.yaml
+++ b/charts/milvus/templates/configmap.yaml
@@ -1,3 +1,5 @@
+# If customConfigMap is not set, this ConfigMap will be redendered.
+{{- if not .Values.customConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,4 +11,5 @@ data:
 {{- range $key, $value := .Values.extraConfigFiles }}
   {{ $key }}: |-
 {{ $value | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/milvus/templates/datacoord-deployment.yaml
+++ b/charts/milvus/templates/datacoord-deployment.yaml
@@ -121,6 +121,12 @@ spec:
         resources:
           {{- toYaml .Values.dataCoordinator.resources | nindent 10 }}
         volumeMounts:
+        {{- if .Values.customConfigMap }}
+        - name: milvus-config
+          mountPath: /milvus/configs/default.yaml
+          subPath: milvus.yaml
+          readOnly: true
+        {{- else }}
         - name: milvus-config
           mountPath: /milvus/configs/default.yaml
           subPath: default.yaml
@@ -129,6 +135,7 @@ spec:
           mountPath: /milvus/configs/user.yaml
           subPath: user.yaml
           readOnly: true
+        {{- end }}
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
@@ -165,7 +172,11 @@ spec:
       volumes:
       - name: milvus-config
         configMap:
+          {{- if .Values.customConfigMap }}
+          name: {{ .Values.customConfigMap }}
+          {{- else }}
           name: {{ template "milvus.fullname" . }}
+          {{- end }}
       {{- if .Values.log.persistence.enabled }}
       - name: milvus-logs-disk
         persistentVolumeClaim:

--- a/charts/milvus/templates/datacoord-deployment.yaml
+++ b/charts/milvus/templates/datacoord-deployment.yaml
@@ -123,7 +123,7 @@ spec:
         volumeMounts:
         {{- if .Values.customConfigMap }}
         - name: milvus-config
-          mountPath: /milvus/configs/default.yaml
+          mountPath: /milvus/configs/user.yaml
           subPath: milvus.yaml
           readOnly: true
         {{- else }}

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -119,7 +119,7 @@ spec:
         volumeMounts:
         {{- if .Values.customConfigMap }}
         - name: milvus-config
-          mountPath: /milvus/configs/default.yaml
+          mountPath: /milvus/configs/user.yaml
           subPath: milvus.yaml
           readOnly: true
         {{- else }}

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -117,6 +117,12 @@ spec:
         resources:
           {{- toYaml .Values.dataNode.resources | nindent 10 }}
         volumeMounts:
+        {{- if .Values.customConfigMap }}
+        - name: milvus-config
+          mountPath: /milvus/configs/default.yaml
+          subPath: milvus.yaml
+          readOnly: true
+        {{- else }}
         - name: milvus-config
           mountPath: /milvus/configs/default.yaml
           subPath: default.yaml
@@ -125,6 +131,7 @@ spec:
           mountPath: /milvus/configs/user.yaml
           subPath: user.yaml
           readOnly: true
+        {{- end }}
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
@@ -160,7 +167,11 @@ spec:
       volumes:
       - name: milvus-config
         configMap:
+          {{- if .Values.customConfigMap }}
+          name: {{ .Values.customConfigMap }}
+          {{- else }}
           name: {{ template "milvus.fullname" . }}
+          {{- end }}
       {{- if .Values.log.persistence.enabled }}
       - name: milvus-logs-disk
         persistentVolumeClaim:

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -121,6 +121,12 @@ spec:
         resources:
           {{- toYaml .Values.indexCoordinator.resources | nindent 10 }}
         volumeMounts:
+        {{- if .Values.customConfigMap }}
+        - name: milvus-config
+          mountPath: /milvus/configs/default.yaml
+          subPath: milvus.yaml
+          readOnly: true
+        {{- else }}
         - name: milvus-config
           mountPath: /milvus/configs/default.yaml
           subPath: default.yaml
@@ -129,6 +135,7 @@ spec:
           mountPath: /milvus/configs/user.yaml
           subPath: user.yaml
           readOnly: true
+        {{- end }}
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
@@ -165,7 +172,11 @@ spec:
       volumes:
       - name: milvus-config
         configMap:
+          {{- if .Values.customConfigMap }}
+          name: {{ .Values.customConfigMap }}
+          {{- else }}
           name: {{ template "milvus.fullname" . }}
+          {{- end }}
       {{- if .Values.log.persistence.enabled }}
       - name: milvus-logs-disk
         persistentVolumeClaim:

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -123,7 +123,7 @@ spec:
         volumeMounts:
         {{- if .Values.customConfigMap }}
         - name: milvus-config
-          mountPath: /milvus/configs/default.yaml
+          mountPath: /milvus/configs/user.yaml
           subPath: milvus.yaml
           readOnly: true
         {{- else }}

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -125,7 +125,7 @@ spec:
         volumeMounts:
         {{- if .Values.customConfigMap }}
         - name: milvus-config
-          mountPath: /milvus/configs/default.yaml
+          mountPath: /milvus/configs/user.yaml
           subPath: milvus.yaml
           readOnly: true
         {{- else }}

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -123,6 +123,12 @@ spec:
         resources:
           {{- toYaml .Values.indexNode.resources | nindent 10 }}
         volumeMounts:
+        {{- if .Values.customConfigMap }}
+        - name: milvus-config
+          mountPath: /milvus/configs/default.yaml
+          subPath: milvus.yaml
+          readOnly: true
+        {{- else }}
         - name: milvus-config
           mountPath: /milvus/configs/default.yaml
           subPath: default.yaml
@@ -131,6 +137,7 @@ spec:
           mountPath: /milvus/configs/user.yaml
           subPath: user.yaml
           readOnly: true
+        {{- end }}
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
@@ -172,7 +179,11 @@ spec:
       volumes:
       - name: milvus-config
         configMap:
+          {{- if .Values.customConfigMap }}
+          name: {{ .Values.customConfigMap }}
+          {{- else }}
           name: {{ template "milvus.fullname" . }}
+          {{- end }}
       {{- if .Values.log.persistence.enabled }}
       - name: milvus-logs-disk
         persistentVolumeClaim:

--- a/charts/milvus/templates/mixcoord-deployment.yaml
+++ b/charts/milvus/templates/mixcoord-deployment.yaml
@@ -118,6 +118,12 @@ spec:
         resources:
           {{- toYaml .Values.mixCoordinator.resources | nindent 10 }}
         volumeMounts:
+        {{- if .Values.customConfigMap }}
+        - name: milvus-config
+          mountPath: /milvus/configs/default.yaml
+          subPath: milvus.yaml
+          readOnly: true
+        {{- else }}
         - name: milvus-config
           mountPath: /milvus/configs/default.yaml
           subPath: default.yaml
@@ -126,6 +132,7 @@ spec:
           mountPath: /milvus/configs/user.yaml
           subPath: user.yaml
           readOnly: true
+        {{- end }}
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
@@ -162,7 +169,11 @@ spec:
       volumes:
       - name: milvus-config
         configMap:
+          {{- if .Values.customConfigMap }}
+          name: {{ .Values.customConfigMap }}
+          {{- else }}
           name: {{ template "milvus.fullname" . }}
+          {{- end }}
       {{- if .Values.log.persistence.enabled }}
       - name: milvus-logs-disk
         persistentVolumeClaim:

--- a/charts/milvus/templates/mixcoord-deployment.yaml
+++ b/charts/milvus/templates/mixcoord-deployment.yaml
@@ -120,7 +120,7 @@ spec:
         volumeMounts:
         {{- if .Values.customConfigMap }}
         - name: milvus-config
-          mountPath: /milvus/configs/default.yaml
+          mountPath: /milvus/configs/user.yaml
           subPath: milvus.yaml
           readOnly: true
         {{- else }}

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -119,7 +119,7 @@ spec:
         volumeMounts:
         {{- if .Values.customConfigMap }}
         - name: milvus-config
-          mountPath: /milvus/configs/default.yaml
+          mountPath: /milvus/configs/user.yaml
           subPath: milvus.yaml
           readOnly: true
         {{- else }}

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -117,6 +117,12 @@ spec:
         resources:
           {{- toYaml .Values.proxy.resources | nindent 10 }}
         volumeMounts:
+        {{- if .Values.customConfigMap }}
+        - name: milvus-config
+          mountPath: /milvus/configs/default.yaml
+          subPath: milvus.yaml
+          readOnly: true
+        {{- else }}
         - name: milvus-config
           mountPath: /milvus/configs/default.yaml
           subPath: default.yaml
@@ -125,6 +131,7 @@ spec:
           mountPath: /milvus/configs/user.yaml
           subPath: user.yaml
           readOnly: true
+        {{- end }}
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
@@ -164,7 +171,11 @@ spec:
       volumes:
       - name: milvus-config
         configMap:
+          {{- if .Values.customConfigMap }}
+          name: {{ .Values.customConfigMap }}
+          {{- else }}
           name: {{ template "milvus.fullname" . }}
+          {{- end }}
       {{- if .Values.log.persistence.enabled }}
       - name: milvus-logs-disk
         persistentVolumeClaim:

--- a/charts/milvus/templates/querycoord-deployment.yaml
+++ b/charts/milvus/templates/querycoord-deployment.yaml
@@ -123,7 +123,7 @@ spec:
         volumeMounts:
         {{- if .Values.customConfigMap }}
         - name: milvus-config
-          mountPath: /milvus/configs/default.yaml
+          mountPath: /milvus/configs/user.yaml
           subPath: milvus.yaml
           readOnly: true
         {{- else }}

--- a/charts/milvus/templates/querycoord-deployment.yaml
+++ b/charts/milvus/templates/querycoord-deployment.yaml
@@ -121,6 +121,12 @@ spec:
         resources:
           {{- toYaml .Values.queryCoordinator.resources | nindent 10 }}
         volumeMounts:
+        {{- if .Values.customConfigMap }}
+        - name: milvus-config
+          mountPath: /milvus/configs/default.yaml
+          subPath: milvus.yaml
+          readOnly: true
+        {{- else }}
         - name: milvus-config
           mountPath: /milvus/configs/default.yaml
           subPath: default.yaml
@@ -129,6 +135,7 @@ spec:
           mountPath: /milvus/configs/user.yaml
           subPath: user.yaml
           readOnly: true
+        {{- end }}
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
@@ -165,7 +172,11 @@ spec:
       volumes:
       - name: milvus-config
         configMap:
+          {{- if .Values.customConfigMap }}
+          name: {{ .Values.customConfigMap }}
+          {{- else }}
           name: {{ template "milvus.fullname" . }}
+          {{- end }}
       {{- if .Values.log.persistence.enabled }}
       - name: milvus-logs-disk
         persistentVolumeClaim:

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -123,6 +123,12 @@ spec:
         resources:
           {{- toYaml .Values.queryNode.resources | nindent 10 }}
         volumeMounts:
+        {{- if .Values.customConfigMap }}
+        - name: milvus-config
+          mountPath: /milvus/configs/default.yaml
+          subPath: milvus.yaml
+          readOnly: true
+        {{- else }}
         - name: milvus-config
           mountPath: /milvus/configs/default.yaml
           subPath: default.yaml
@@ -131,6 +137,7 @@ spec:
           mountPath: /milvus/configs/user.yaml
           subPath: user.yaml
           readOnly: true
+        {{- end }}
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
@@ -171,7 +178,11 @@ spec:
       volumes:
       - name: milvus-config
         configMap:
+          {{- if .Values.customConfigMap }}
+          name: {{ .Values.customConfigMap }}
+          {{- else }}
           name: {{ template "milvus.fullname" . }}
+          {{- end }}
       {{- if .Values.log.persistence.enabled }}
       - name: milvus-logs-disk
         persistentVolumeClaim:

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -125,7 +125,7 @@ spec:
         volumeMounts:
         {{- if .Values.customConfigMap }}
         - name: milvus-config
-          mountPath: /milvus/configs/default.yaml
+          mountPath: /milvus/configs/user.yaml
           subPath: milvus.yaml
           readOnly: true
         {{- else }}

--- a/charts/milvus/templates/rootcoord-deployment.yaml
+++ b/charts/milvus/templates/rootcoord-deployment.yaml
@@ -123,7 +123,7 @@ spec:
         volumeMounts:
         {{- if .Values.customConfigMap }}
         - name: milvus-config
-          mountPath: /milvus/configs/default.yaml
+          mountPath: /milvus/configs/user.yaml
           subPath: milvus.yaml
           readOnly: true
         {{- else }}

--- a/charts/milvus/templates/rootcoord-deployment.yaml
+++ b/charts/milvus/templates/rootcoord-deployment.yaml
@@ -121,6 +121,12 @@ spec:
         resources:
           {{- toYaml .Values.rootCoordinator.resources | nindent 10 }}
         volumeMounts:
+        {{- if .Values.customConfigMap }}
+        - name: milvus-config
+          mountPath: /milvus/configs/default.yaml
+          subPath: milvus.yaml
+          readOnly: true
+        {{- else }}
         - name: milvus-config
           mountPath: /milvus/configs/default.yaml
           subPath: default.yaml
@@ -129,6 +135,7 @@ spec:
           mountPath: /milvus/configs/user.yaml
           subPath: user.yaml
           readOnly: true
+        {{- end }}
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
@@ -165,7 +172,11 @@ spec:
       volumes:
       - name: milvus-config
         configMap:
+          {{- if .Values.customConfigMap }}
+          name: {{ .Values.customConfigMap }}
+          {{- else }}
           name: {{ template "milvus.fullname" . }}
+          {{- end }}
       {{- if .Values.log.persistence.enabled }}
       - name: milvus-logs-disk
         persistentVolumeClaim:

--- a/charts/milvus/templates/standalone-deployment.yaml
+++ b/charts/milvus/templates/standalone-deployment.yaml
@@ -121,6 +121,12 @@ spec:
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
+        {{- if .Values.customConfigMap }}
+        - name: milvus-config
+          mountPath: /milvus/configs/default.yaml
+          subPath: milvus.yaml
+          readOnly: true
+        {{- else }}
         - name: milvus-config
           mountPath: /milvus/configs/default.yaml
           subPath: default.yaml
@@ -129,6 +135,7 @@ spec:
           mountPath: /milvus/configs/user.yaml
           subPath: user.yaml
           readOnly: true
+        {{- end }}
         - name: milvus-data-disk
           mountPath: {{ .Values.standalone.persistence.mountPath | quote }}
           subPath: {{ .Values.standalone.persistence.persistentVolumeClaim.subPath | default "" }}
@@ -172,7 +179,11 @@ spec:
         name: tools
       - name: milvus-config
         configMap:
+          {{- if .Values.customConfigMap }}
+          name: {{ .Values.customConfigMap }}
+          {{- else }}
           name: {{ template "milvus.fullname" . }}
+          {{- end }}
       - name: milvus-data-disk
         {{- if .Values.standalone.persistence.enabled }}
         persistentVolumeClaim:

--- a/charts/milvus/templates/standalone-deployment.yaml
+++ b/charts/milvus/templates/standalone-deployment.yaml
@@ -123,7 +123,7 @@ spec:
           name: tools
         {{- if .Values.customConfigMap }}
         - name: milvus-config
-          mountPath: /milvus/configs/default.yaml
+          mountPath: /milvus/configs/user.yaml
           subPath: milvus.yaml
           readOnly: true
         {{- else }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -38,6 +38,13 @@ affinity: {}
 labels: {}
 annotations: {}
 
+##
+## If set, the whole config will be mounted from this custom ConfigMap.
+## The ConfigMap should have a key named `milvus.yaml` which contains the full Milvus config.
+## extraConfigFiles will be ignored if this variable is set.
+##
+customConfigMap: ""
+
 # Extra configs for milvus.yaml
 # If set, this config will merge into milvus.yaml
 # Please follow the config structure in the milvus.yaml


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds an extra config field which allows users to use a completely custom ConfigMap for configuring Milvus. This is useful for situation where dynamic info needs to be added to the configmap for various reasons (example: configuring storage account ID based on some automatically provisioned resource).

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
