### PR TITLE
[milvus] Change kafka as default MQ

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.4.5"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.1.34
+version: 4.1.35
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -603,7 +603,7 @@ etcd:
 ##
 
 pulsar:
-  enabled: true
+  enabled: false
   name: pulsar
 
   fullnameOverride: ""
@@ -802,7 +802,7 @@ pulsar:
 ##
 
 kafka:
-  enabled: false
+  enabled: true
   name: kafka
   replicaCount: 3
   image:


### PR DESCRIPTION
## What this PR does / why we need it:
Change kafka as default MQ.

Originally posted by https://milvus.io/tools/sizing 

**1 Million of vectors, 128 Dimensions with 512MB segment** 

Pulsar: 
![image](https://github.com/zilliztech/milvus-helm/assets/5010507/aeb47fcd-3d64-41e6-9aa7-c46eb12b6909)

kafka:
![image](https://github.com/zilliztech/milvus-helm/assets/5010507/ee67a74e-b4e3-4630-8e27-4bf93c324747)

| | Pulsar | kafka |
|--| -- | -- |
| CPU | 40Core | 32Core |
| Memory |167GB | 112GB |
| SSD | 240GB | 150GB |
| Disk | 70GB | 70GB |


## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
