### PR TITLE
Use mixcoord for milvus cluster by default

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.4.7"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.2.3
+version: 4.2.4
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -106,21 +106,22 @@ By default, milvus cluster uses `pulsar` as message queue. You can also use `kaf
 $ helm upgrade --install my-release milvus/milvus --set pulsar.enabled=false --set kafka.enabled=true
 ```
 
-By default, milvus cluster uses several separate coordinators. You can also use mixCoordinator instead which contains all coordinators.
+By default, milvus cluster uses `mixCoordinator` instead which contains all coordinators since milvus-helm chart 4.2.4. To use separate coordinators, you can disable `mixCoordinator` and enable all the coordinators separately:
+
 
 ```bash
 # Helm v3.x
 $ cat << EOF > values-custom.yaml
 mixCoordinator:
-  enabled: true
+  enabled: false
 rootCoordinator:
-  enabled: false
+  enabled: true
 indexCoordinator:
-  enabled: false
+  enabled: true
 queryCoordinator:
-  enabled: false
+  enabled: true
 dataCoordinator:
-  enabled: false
+  enabled: true
 EOF
 $ helm upgrade --install my-release milvus/milvus -f values-custom.yaml
 ```
@@ -137,10 +138,10 @@ $ helm upgrade --install --set queryNode.replicas=2 my-release milvus/milvus
 ```
 
 ### Milvus Coordinator Active Standby
-> **IMPORTANT** Milvus helm chart 4.0.7 (Milvus 2.2.3) support deploying multiple coordinators. For example, you run a Milvus cluster with two rootcoord pods:
+> **IMPORTANT** Milvus helm chart 4.0.7 (Milvus 2.2.3) support deploying multiple coordinators. For example, you run a Milvus cluster with two mixcoord pods:
 
 ```bash
-helm upgrade --install my-release milvus/milvus --set rootCoordinator.activeStandby.enabled=true --set rootCoordinator.replicas=2
+helm upgrade --install my-release milvus/milvus --set mixCoordinator.activeStandby.enabled=true --set mixCoordinator.replicas=2
 ```
 
 ### Breaking Changes
@@ -387,7 +388,7 @@ The following table lists the configurable parameters of the Milvus Root Coordin
 
 | Parameter                                 | Description                                   | Default                                                 |
 |-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
-| `rootCoordinator.enabled`                 | Enable or disable Milvus Root Coordinator component  | `true`                                           |
+| `rootCoordinator.enabled`                 | Enable or disable Milvus Root Coordinator component  | `false`                                           |
 | `rootCoordinator.resources`               | Resource requests/limits for the Milvus Root Coordinator pods | `{}`                                    |
 | `rootCoordinator.nodeSelector`            | Node labels for Milvus Root Coordinator pods assignment | `{}`                                          |
 | `rootCoordinator.affinity`                | Affinity settings for Milvus Root Coordinator pods assignment | `{}`                                    |
@@ -411,7 +412,7 @@ The following table lists the configurable parameters of the Milvus Query Coordi
 
 | Parameter                                 | Description                                   | Default                                                 |
 |-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
-| `queryCoordinator.enabled`                | Enable or disable Query Coordinator component | `true`                                                  |
+| `queryCoordinator.enabled`                | Enable or disable Query Coordinator component | `false`                                                  |
 | `queryCoordinator.resources`              | Resource requests/limits for the Milvus Query Coordinator pods | `{}`                                   |
 | `queryCoordinator.nodeSelector`           | Node labels for Milvus Query Coordinator pods assignment | `{}`                                         |
 | `queryCoordinator.affinity`               | Affinity settings for Milvus Query Coordinator pods assignment | `{}`                                   |
@@ -453,7 +454,7 @@ The following table lists the configurable parameters of the Milvus Index Coordi
 
 | Parameter                                 | Description                                   | Default                                                 |
 |-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
-| `indexCoordinator.enabled`                | Enable or disable Index Coordinator component | `true`                                                  |
+| `indexCoordinator.enabled`                | Enable or disable Index Coordinator component | `false`                                                  |
 | `indexCoordinator.resources`              | Resource requests/limits for the Milvus Index Coordinator pods | `{}`                                   |
 | `indexCoordinator.nodeSelector`           | Node labels for Milvus Index Coordinator pods assignment | `{}`                                         |
 | `indexCoordinator.affinity`               | Affinity settings for Milvus Index Coordinator pods assignment | `{}`                                   |
@@ -495,7 +496,7 @@ The following table lists the configurable parameters of the Milvus Data Coordin
 
 | Parameter                                 | Description                                   | Default                                                 |
 |-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
-| `dataCoordinator.enabled`                 | Enable or disable Data Coordinator component  | `true`                                                  |
+| `dataCoordinator.enabled`                 | Enable or disable Data Coordinator component  | `false`                                                  |
 | `dataCoordinator.resources`               | Resource requests/limits for the Milvus Data Coordinator pods | `{}`                                    |
 | `dataCoordinator.nodeSelector`            | Node labels for Milvus Data Coordinator pods assignment | `{}`                                          |
 | `dataCoordinator.affinity`                | Affinity settings for Milvus Data Coordinator pods assignment  | `{}`                                   |

--- a/charts/milvus/templates/mixcoord-deployment.yaml
+++ b/charts/milvus/templates/mixcoord-deployment.yaml
@@ -68,7 +68,7 @@ spec:
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
         {{- if .Values.mixCoordinator.heaptrack.enabled }}
-        args: [ "/milvus/tools/run-helm.sh", "milvus", "run", "mixture", "-rootcoord", "-querycoord", "-datacoord", "-indexcoord" ]
+        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "mixture", "-rootcoord", "-querycoord", "-datacoord", "-indexcoord" ]
         {{- else }}
         args: [ "milvus", "run", "mixture", "-rootcoord", "-querycoord", "-datacoord", "-indexcoord" ]
         {{- end }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -275,7 +275,7 @@ proxy:
   strategy: {}
 
 rootCoordinator:
-  enabled: true
+  enabled: false
   # You can set the number of replicas greater than 1, only if enable active standby
   replicas: 1  # Run Root Coordinator mode with replication disabled
   resources: {}
@@ -300,7 +300,7 @@ rootCoordinator:
     clusterIP: ""
 
 queryCoordinator:
-  enabled: true
+  enabled: false
   # You can set the number of replicas greater than 1, only if enable active standby
   replicas: 1  # Run Query Coordinator mode with replication disabled
   resources: {}
@@ -350,7 +350,7 @@ queryNode:
   strategy: {}
 
 indexCoordinator:
-  enabled: true
+  enabled: false
   # You can set the number of replicas greater than 1, only if enable active standby
   replicas: 1   # Run Index Coordinator mode with replication disabled
   resources: {}
@@ -399,7 +399,7 @@ indexNode:
   strategy: {}
 
 dataCoordinator:
-  enabled: true
+  enabled: false
   # You can set the number of replicas greater than 1, only if enable active standby
   replicas: 1           # Run Data Coordinator mode with replication disabled
   resources: {}
@@ -443,7 +443,7 @@ dataNode:
 ## mixCoordinator contains all coord
 ## If you want to use mixcoord, enable this and disable all of other coords
 mixCoordinator:
-  enabled: false
+  enabled: true
   # You can set the number of replicas greater than 1, only if enable active standby
   replicas: 1           # Run Mixture Coordinator mode with replication disabled
   resources: {}


### PR DESCRIPTION
## What this PR does / why we need it:
Use mixcoord instead of separate rootcoord, datacoord, querycoord and indexcoord.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Chart Version bumped
- [ x] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
