### PR TITLE
[milvus] bump attu version to v2.4.7

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.4.9"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.2.6
+version: 4.2.7
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -471,7 +471,7 @@ attu:
   name: attu
   image:
     repository: zilliz/attu
-    tag: v2.4.6
+    tag: v2.4.7
     pullPolicy: IfNotPresent
   service:
     annotations: {}


### PR DESCRIPTION
## What this PR does / why we need it:
Attu v2.4.7 was released with two security patches, the user is asking to bump the version here as well. 

https://github.com/zilliztech/attu/issues/622

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
