### PR TITLE
[milvus] Fix attu ingress class

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.4.10"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.2.9
+version: 4.2.10
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/attu-ingress.yaml
+++ b/charts/milvus/templates/attu-ingress.yaml
@@ -18,8 +18,8 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.attu.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.attu.ingress.ingressClassName }}
 {{- end }}
 {{- if .Values.attu.ingress.tls }}
   tls:


### PR DESCRIPTION
## What this PR does / why we need it:
This PR fixes the ingress classname for `Attu` and allows using 2 different ingress classes between `Milvus` and `Attu`.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [?] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [X] PR only contains changes for one chart
