### PR TITLE
[milvus] Support custom annotations in pod deployments

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.4.14"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.2.17
+version: 4.2.18
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -381,6 +381,7 @@ The following table lists the configurable parameters of the Milvus Proxy compon
 | `proxy.http.debugMode.enabled`            | Enable debug mode for rest api                          | `false`       |
 | `proxy.tls.enabled`                       | Enable porxy tls connection                             | `false`       |
 | `proxy.strategy`                          | Deployment strategy configuration                       | RollingUpdate |
+| `proxy.annotations`                       | Additional pod annotations                              | `{}`          |
 
 ### Milvus Root Coordinator Deployment Configuration
 
@@ -406,6 +407,7 @@ The following table lists the configurable parameters of the Milvus Root Coordin
 | `rootCoordinator.service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to lb (if supported) | `[]`                                  |
 | `rootCoordinator.service.externalIPs`             | Service external IP addresses                 | `[]`                                         |
 | `rootCoordinator.strategy`                       | Deployment strategy configuration |  RollingUpdate                                         |
+| `rootCoordinator.annotations`                    | Additional pod annotations | `{}` |
 ### Milvus Query Coordinator Deployment Configuration
 
 The following table lists the configurable parameters of the Milvus Query Coordinator component and their default values.
@@ -430,6 +432,7 @@ The following table lists the configurable parameters of the Milvus Query Coordi
 | `queryCoordinator.service.loadBalancerSourceRanges`   | List of IP CIDRs allowed access to lb (if supported) | `[]`                                 |
 | `queryCoordinator.service.externalIPs`                | Service external IP addresses                 | `[]`                                        |
 | `queryCoordinator.strategy`                       | Deployment strategy configuration |  RollingUpdate                                         |
+| `queryCoordinator.annotations`                    | Additional pod annotations | `{}` |
 ### Milvus Query Node Deployment Configuration
 
 The following table lists the configurable parameters of the Milvus Query Node component and their default values.
@@ -447,6 +450,7 @@ The following table lists the configurable parameters of the Milvus Query Node c
 | `queryNode.profiling.enabled`             | Whether to enable live profiling                   | `false`                                          |
 | `queryNode.extraEnv`                      | Additional Milvus Query Node container environment variables | `[]`                                     |
 | `queryNode.strategy`                      | Deployment strategy configuration |  RollingUpdate                                         |
+| `queryNode.annotations`                    | Additional pod annotations | `{}` |
 
 ### Milvus Index Coordinator Deployment Configuration
 
@@ -472,6 +476,7 @@ The following table lists the configurable parameters of the Milvus Index Coordi
 | `indexCoordinator.service.loadBalancerSourceRanges`   | List of IP CIDRs allowed access to lb (if supported) | `[]`                                 |
 | `indexCoordinator.service.externalIPs`                | Service external IP addresses                 | `[]`                                        |
 | `indexCoordinator.strategy`                       | Deployment strategy configuration |  RollingUpdate                                         |
+| `indexCoordinator.annotations`                    | Additional pod annotations | `{}` |
 ### Milvus Index Node Deployment Configuration
 
 The following table lists the configurable parameters of the Milvus Index Node component and their default values.
@@ -489,6 +494,7 @@ The following table lists the configurable parameters of the Milvus Index Node c
 | `indexNode.profiling.enabled`             | Whether to enable live profiling                   | `false`                                          |
 | `indexNode.extraEnv`                      | Additional Milvus Index Node container environment variables | `[]`                                     |
 | `indexNode.strategy`                      | Deployment strategy configuration |  RollingUpdate                                         |
+| `indexNode.annotations`                    | Additional pod annotations | `{}` |
 
 ### Milvus Data Coordinator Deployment Configuration
 
@@ -514,6 +520,7 @@ The following table lists the configurable parameters of the Milvus Data Coordin
 | `dataCoordinator.service.loadBalancerSourceRanges`    | List of IP CIDRs allowed access to lb (if supported) | `[]`                                 |
 | `dataCoordinator.service.externalIPs`                 | Service external IP addresses                 | `[]`                                        |
 | `dataCoordinator.strategy`                       | Deployment strategy configuration |  RollingUpdate                                         |
+| `dataCoordinator.annotations`                    | Additional pod annotations | `{}` |
 ### Milvus Data Node Deployment Configuration
 
 The following table lists the configurable parameters of the Milvus Data Node component and their default values.
@@ -530,6 +537,7 @@ The following table lists the configurable parameters of the Milvus Data Node co
 | `dataNode.profiling.enabled`              | Whether to enable live profiling                   | `false`                                          |
 | `dataNode.extraEnv`                       | Additional Milvus Data Node container environment variables | `[]`                                      |
 | `dataNode.strategy`                       | Deployment strategy configuration |  RollingUpdate                                         |
+| `dataNode.annotations`                    | Additional pod annotations | `{}` |
 
 ### Milvus Mixture Coordinator Deployment Configuration
 
@@ -554,6 +562,7 @@ The following table lists the configurable parameters of the Milvus Mixture Coor
 | `mixCoordinator.service.loadBalancerSourceRanges`    | List of IP CIDRs allowed access to lb (if supported) | `[]`                                 |
 | `mixCoordinator.service.externalIPs`                 | Service external IP addresses                 | `[]`                                        |
 | `mixCoordinator.strategy`                       | Deployment strategy configuration |  RollingUpdate                                         |
+| `mixCoordinator.annotations`                    | Additional pod annotations | `{}` |
 ### Pulsar Configuration
 
 This version of the chart includes the dependent Pulsar chart in the charts/ directory.

--- a/charts/milvus/templates/datacoord-deployment.yaml
+++ b/charts/milvus/templates/datacoord-deployment.yaml
@@ -40,6 +40,9 @@ spec:
         pyroscope.io/application-name: {{ template "milvus.datacoord.fullname" . }}
         pyroscope.io/port: "9091"
       {{- end }}
+      {{- if .Values.dataCoordinator.annotations }}
+        {{- toYaml .Values.dataCoordinator.annotations | nindent 8 }}
+      {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         pyroscope.io/application-name: {{ template "milvus.datanode.fullname" . }}
         pyroscope.io/port: "9091"
       {{- end }}
+      {{- if .Values.dataNode.annotations }}
+        {{- toYaml .Values.dataNode.annotations | nindent 8 }}
+      {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -40,6 +40,9 @@ spec:
         pyroscope.io/application-name: {{ template "milvus.indexcoord.fullname" . }}
         pyroscope.io/port: "9091"
       {{- end }}
+      {{- if .Values.indexCoordinator.annotations }}
+        {{- toYaml .Values.indexCoordinator.annotations | nindent 8 }}
+      {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -35,6 +35,9 @@ spec:
         pyroscope.io/application-name: {{ template "milvus.indexnode.fullname" . }}
         pyroscope.io/port: "9091"
       {{- end }}
+      {{- if .Values.indexNode.annotations }}
+        {{- toYaml .Values.indexNode.annotations | nindent 8 }}
+      {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:

--- a/charts/milvus/templates/mixcoord-deployment.yaml
+++ b/charts/milvus/templates/mixcoord-deployment.yaml
@@ -40,6 +40,9 @@ spec:
         pyroscope.io/application-name: {{ template "milvus.mixcoord.fullname" . }}
         pyroscope.io/port: "9091"
       {{- end }}
+      {{- if .Values.mixCoordinator.annotations }}
+        {{- toYaml .Values.mixCoordinator.annotations | nindent 8 }}
+      {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         pyroscope.io/application-name: {{ template "milvus.proxy.fullname" . }}
         pyroscope.io/port: "9091"
       {{- end }}
+      {{- if .Values.proxy.annotations }}
+        {{- toYaml .Values.proxy.annotations | nindent 8 }}
+      {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:

--- a/charts/milvus/templates/querycoord-deployment.yaml
+++ b/charts/milvus/templates/querycoord-deployment.yaml
@@ -40,6 +40,9 @@ spec:
         pyroscope.io/application-name: {{ template "milvus.querycoord.fullname" . }}
         pyroscope.io/port: "9091"
       {{- end }}
+      {{- if .Values.queryCoordinator.annotations }}
+        {{- toYaml .Values.queryCoordinator.annotations | nindent 8 }}
+      {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -35,6 +35,9 @@ spec:
         pyroscope.io/application-name: {{ template "milvus.querynode.fullname" . }}
         pyroscope.io/port: "9091"
       {{- end }}
+      {{- if .Values.queryNode.annotations }}
+        {{- toYaml .Values.queryNode.annotations | nindent 8 }}
+      {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:

--- a/charts/milvus/templates/rootcoord-deployment.yaml
+++ b/charts/milvus/templates/rootcoord-deployment.yaml
@@ -40,6 +40,9 @@ spec:
         pyroscope.io/application-name: {{ template "milvus.rootcoord.fullname" . }}
         pyroscope.io/port: "9091"
       {{- end }}
+      {{- if .Values.rootCoordinator.annotations }}
+        {{- toYaml .Values.rootCoordinator.annotations | nindent 8 }}
+      {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -280,6 +280,7 @@ proxy:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  annotations: {}
 
 rootCoordinator:
   enabled: false
@@ -299,6 +300,7 @@ rootCoordinator:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  annotations: {}
 
   service:
     port: 53100
@@ -324,6 +326,7 @@ queryCoordinator:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  annotations: {}
 
   service:
     port: 19531
@@ -355,6 +358,7 @@ queryNode:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  annotations: {}
 
 indexCoordinator:
   enabled: false
@@ -374,6 +378,7 @@ indexCoordinator:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  annotations: {}
 
   service:
     port: 31000
@@ -404,6 +409,7 @@ indexNode:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  annotations: {}
 
 dataCoordinator:
   enabled: false
@@ -423,6 +429,7 @@ dataCoordinator:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  annotations: {}
 
   service:
     port: 13333
@@ -446,6 +453,7 @@ dataNode:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  annotations: {}
 
 ## mixCoordinator contains all coord
 ## If you want to use mixcoord, enable this and disable all of other coords
@@ -467,6 +475,7 @@ mixCoordinator:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  annotations: {}
 
   service:
     annotations: {}


### PR DESCRIPTION
## What this PR does / why we need it:

To support datadog container autodiscovery, we need annotations attached directly to pods. The existing helm chart only supports custom annotations attached to services.

https://docs.datadoghq.com/containers/kubernetes/prometheus/

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
