### PR TITLE
[milvus] Set hpa to allow queryNode, indexNode, proxy, and dataNode to automatically scale

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.5.5"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.2.40
+version: 4.2.41
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -387,9 +387,9 @@ The following table lists the configurable parameters of the Milvus Proxy compon
 | `proxy.strategy`                          | Deployment strategy configuration                       | RollingUpdate |
 | `proxy.annotations`                       | Additional pod annotations                              | `{}`          |
 | `proxy.hpa` | Enable hpa for proxy node | false |
-| `proxy.minReplicas` | Specify the minimum number of replicas | false |
-| `proxy.maxReplicas` | Specify the maximum number of replicas | false |
-| `proxy.cpuUtilization` | Specify the cpu auto-scaling valve | false |
+| `proxy.minReplicas` | Specify the minimum number of replicas | 1 |
+| `proxy.maxReplicas` | Specify the maximum number of replicas | 5 |
+| `proxy.cpuUtilization` | Specify the cpu auto-scaling valve | 40 |
 
 ### Milvus Root Coordinator Deployment Configuration
 
@@ -460,9 +460,9 @@ The following table lists the configurable parameters of the Milvus Query Node c
 | `queryNode.strategy`                      | Deployment strategy configuration |  RollingUpdate                                         |
 | `queryNode.annotations`                    | Additional pod annotations | `{}` |
 | `queryNode.hpa` | Enable hpa for query node | false |
-| `queryNode.minReplicas` | Specify the minimum number of replicas | false |
-| `queryNode.maxReplicas` | Specify the maximum number of replicas | false |
-| `queryNode.cpuUtilization` | Specify the cpu auto-scaling valve | false |
+| `queryNode.minReplicas` | Specify the minimum number of replicas | 1 |
+| `queryNode.maxReplicas` | Specify the maximum number of replicas | 5 |
+| `queryNode.cpuUtilization` | Specify the cpu auto-scaling valve | 40 |
 
 ### Milvus Index Coordinator Deployment Configuration
 
@@ -508,9 +508,9 @@ The following table lists the configurable parameters of the Milvus Index Node c
 | `indexNode.strategy`                      | Deployment strategy configuration |  RollingUpdate                                         |
 | `indexNode.annotations`                    | Additional pod annotations | `{}` |
 | `indexNode.hpa` | Enable hpa for index node | false |
-| `indexNode.minReplicas` | Specify the minimum number of replicas | false |
-| `indexNode.maxReplicas` | Specify the maximum number of replicas | false |
-| `indexNode.cpuUtilization` | Specify the cpu auto-scaling valve | false |
+| `indexNode.minReplicas` | Specify the minimum number of replicas | 1 |
+| `indexNode.maxReplicas` | Specify the maximum number of replicas | 5 |
+| `indexNode.cpuUtilization` | Specify the cpu auto-scaling valve | 40 |
 
 ### Milvus Data Coordinator Deployment Configuration
 
@@ -555,9 +555,9 @@ The following table lists the configurable parameters of the Milvus Data Node co
 | `dataNode.strategy`                       | Deployment strategy configuration |  RollingUpdate                                         |
 | `dataNode.annotations`                    | Additional pod annotations | `{}` |
 | `dataNode.hpa` | Enable hpa for data node | false |
-| `dataNode.minReplicas` | Specify the minimum number of replicas | false |
-| `dataNode.maxReplicas` | Specify the maximum number of replicas | false |
-| `dataNode.cpuUtilization` | Specify the cpu auto-scaling valve | false |
+| `dataNode.minReplicas` | Specify the minimum number of replicas | 1 |
+| `dataNode.maxReplicas` | Specify the maximum number of replicas | 5 |
+| `dataNode.cpuUtilization` | Specify the cpu auto-scaling valve | 40 |
 
 ### Milvus Mixture Coordinator Deployment Configuration
 

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -386,6 +386,10 @@ The following table lists the configurable parameters of the Milvus Proxy compon
 | `proxy.tls.enabled`                       | Enable porxy tls connection                             | `false`       |
 | `proxy.strategy`                          | Deployment strategy configuration                       | RollingUpdate |
 | `proxy.annotations`                       | Additional pod annotations                              | `{}`          |
+| `proxy.hpa` | Enable hpa for proxy node | false |
+| `proxy.minReplicas` | Specify the minimum number of replicas | false |
+| `proxy.maxReplicas` | Specify the maximum number of replicas | false |
+| `proxy.cpuUtilization` | Specify the cpu auto-scaling valve | false |
 
 ### Milvus Root Coordinator Deployment Configuration
 
@@ -455,6 +459,10 @@ The following table lists the configurable parameters of the Milvus Query Node c
 | `queryNode.extraEnv`                      | Additional Milvus Query Node container environment variables | `[]`                                     |
 | `queryNode.strategy`                      | Deployment strategy configuration |  RollingUpdate                                         |
 | `queryNode.annotations`                    | Additional pod annotations | `{}` |
+| `queryNode.hpa` | Enable hpa for query node | false |
+| `queryNode.minReplicas` | Specify the minimum number of replicas | false |
+| `queryNode.maxReplicas` | Specify the maximum number of replicas | false |
+| `queryNode.cpuUtilization` | Specify the cpu auto-scaling valve | false |
 
 ### Milvus Index Coordinator Deployment Configuration
 
@@ -499,6 +507,10 @@ The following table lists the configurable parameters of the Milvus Index Node c
 | `indexNode.extraEnv`                      | Additional Milvus Index Node container environment variables | `[]`                                     |
 | `indexNode.strategy`                      | Deployment strategy configuration |  RollingUpdate                                         |
 | `indexNode.annotations`                    | Additional pod annotations | `{}` |
+| `indexNode.hpa` | Enable hpa for index node | false |
+| `indexNode.minReplicas` | Specify the minimum number of replicas | false |
+| `indexNode.maxReplicas` | Specify the maximum number of replicas | false |
+| `indexNode.cpuUtilization` | Specify the cpu auto-scaling valve | false |
 
 ### Milvus Data Coordinator Deployment Configuration
 
@@ -542,6 +554,10 @@ The following table lists the configurable parameters of the Milvus Data Node co
 | `dataNode.extraEnv`                       | Additional Milvus Data Node container environment variables | `[]`                                      |
 | `dataNode.strategy`                       | Deployment strategy configuration |  RollingUpdate                                         |
 | `dataNode.annotations`                    | Additional pod annotations | `{}` |
+| `dataNode.hpa` | Enable hpa for data node | false |
+| `dataNode.minReplicas` | Specify the minimum number of replicas | false |
+| `dataNode.maxReplicas` | Specify the maximum number of replicas | false |
+| `dataNode.cpuUtilization` | Specify the cpu auto-scaling valve | false |
 
 ### Milvus Mixture Coordinator Deployment Configuration
 

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -389,7 +389,7 @@ The following table lists the configurable parameters of the Milvus Proxy compon
 | `proxy.hpa` | Enable hpa for proxy node | false |
 | `proxy.minReplicas` | Specify the minimum number of replicas | 1 |
 | `proxy.maxReplicas` | Specify the maximum number of replicas | 5 |
-| `proxy.cpuUtilization` | Specify the cpu auto-scaling valve | 40 |
+| `proxy.cpuUtilization` | Specify the cpu auto-scaling value | 40 |
 
 ### Milvus Root Coordinator Deployment Configuration
 
@@ -462,7 +462,7 @@ The following table lists the configurable parameters of the Milvus Query Node c
 | `queryNode.hpa` | Enable hpa for query node | false |
 | `queryNode.minReplicas` | Specify the minimum number of replicas | 1 |
 | `queryNode.maxReplicas` | Specify the maximum number of replicas | 5 |
-| `queryNode.cpuUtilization` | Specify the cpu auto-scaling valve | 40 |
+| `queryNode.cpuUtilization` | Specify the cpu auto-scaling value | 40 |
 
 ### Milvus Index Coordinator Deployment Configuration
 
@@ -510,7 +510,7 @@ The following table lists the configurable parameters of the Milvus Index Node c
 | `indexNode.hpa` | Enable hpa for index node | false |
 | `indexNode.minReplicas` | Specify the minimum number of replicas | 1 |
 | `indexNode.maxReplicas` | Specify the maximum number of replicas | 5 |
-| `indexNode.cpuUtilization` | Specify the cpu auto-scaling valve | 40 |
+| `indexNode.cpuUtilization` | Specify the cpu auto-scaling value | 40 |
 
 ### Milvus Data Coordinator Deployment Configuration
 
@@ -557,7 +557,7 @@ The following table lists the configurable parameters of the Milvus Data Node co
 | `dataNode.hpa` | Enable hpa for data node | false |
 | `dataNode.minReplicas` | Specify the minimum number of replicas | 1 |
 | `dataNode.maxReplicas` | Specify the maximum number of replicas | 5 |
-| `dataNode.cpuUtilization` | Specify the cpu auto-scaling valve | 40 |
+| `dataNode.cpuUtilization` | Specify the cpu auto-scaling value | 40 |
 
 ### Milvus Mixture Coordinator Deployment Configuration
 

--- a/charts/milvus/templates/datanode-hpa.yaml
+++ b/charts/milvus/templates/datanode-hpa.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.dataNode.enabled .Values.dataNode.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "milvus.datanode.fullname" . }}-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: "datanode"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "milvus.datanode.fullname" . }}
+  minReplicas: {{ .Values.dataNode.hpa.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.dataNode.hpa.maxReplicas | default 10 }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.dataNode.hpa.cpuUtilization | default 50 }}
+{{- end }}

--- a/charts/milvus/templates/indexnode-hpa.yaml
+++ b/charts/milvus/templates/indexnode-hpa.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.indexNode.enabled .Values.indexNode.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "milvus.indexnode.fullname" . }}-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: "indexnode"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "milvus.indexnode.fullname" . }}
+  minReplicas: {{ .Values.indexNode.hpa.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.indexNode.hpa.maxReplicas | default 10 }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.indexNode.hpa.cpuUtilization | default 50 }}
+{{- end }}

--- a/charts/milvus/templates/proxy-hpa.yaml
+++ b/charts/milvus/templates/proxy-hpa.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.proxy.enabled .Values.proxy.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "milvus.proxy.fullname" . }}-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: "proxy"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "milvus.proxy.fullname" . }}
+  minReplicas: {{ .Values.proxy.hpa.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.proxy.hpa.maxReplicas | default 10 }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.proxy.hpa.cpuUtilization | default 50 }}
+{{- end }}

--- a/charts/milvus/templates/querynode-hpa.yaml
+++ b/charts/milvus/templates/querynode-hpa.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.queryNode.enabled .Values.queryNode.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "milvus.querynode.fullname" . }}-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: "querynode"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "milvus.querynode.fullname" . }}
+  minReplicas: {{ .Values.queryNode.hpa.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.queryNode.hpa.maxReplicas | default 10 }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.queryNode.hpa.cpuUtilization | default 50 }}
+{{- end }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -301,6 +301,11 @@ proxy:
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
   annotations: {}
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    cpuUtilization: 40
 
 rootCoordinator:
   enabled: false
@@ -382,6 +387,11 @@ queryNode:
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
   annotations: {}
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    cpuUtilization: 40
 
 indexCoordinator:
   enabled: false
@@ -435,6 +445,11 @@ indexNode:
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
   annotations: {}
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    cpuUtilization: 40
 
 dataCoordinator:
   enabled: false
@@ -481,6 +496,11 @@ dataNode:
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
   annotations: {}
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    cpuUtilization: 40
 
 ## mixCoordinator contains all coord
 ## If you want to use mixcoord, enable this and disable all of other coords


### PR DESCRIPTION
## What this PR does / why we need it:
This PR enhances the Milvus Helm chart by incorporating scale-out deployment capabilities. It is based on the recommendations provided in the [scaleout documentation](https://milvus.io/docs/zh-hant/scaleout.md) and addresses the feedback outlined in [issue #100](https://github.com/zilliztech/milvus-helm/issues/100).

Key changes include:
- Setup HPA for stateless worker nodes include query node, data node, index node, and proxy.


## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [v] Chart Version bumped
- [v] Variables are documented in the README.md
- [v] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [v] PR only contains changes for one chart
