### PR TITLE
[milvus] Added memory threshold for query node hpa and unified default settings for templates and README

### DIFF
--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -463,6 +463,7 @@ The following table lists the configurable parameters of the Milvus Query Node c
 | `queryNode.minReplicas` | Specify the minimum number of replicas | 1 |
 | `queryNode.maxReplicas` | Specify the maximum number of replicas | 5 |
 | `queryNode.cpuUtilization` | Specify the cpu auto-scaling value | 40 |
+| `queryNode.memoryUtilization` | Specify the memory auto-scaling value | 40 |
 
 ### Milvus Index Coordinator Deployment Configuration
 

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -463,7 +463,7 @@ The following table lists the configurable parameters of the Milvus Query Node c
 | `queryNode.minReplicas` | Specify the minimum number of replicas | 1 |
 | `queryNode.maxReplicas` | Specify the maximum number of replicas | 5 |
 | `queryNode.cpuUtilization` | Specify the cpu auto-scaling value | 40 |
-| `queryNode.memoryUtilization` | Specify the memory auto-scaling value | 40 |
+| `queryNode.memoryUtilization` | Specify the memory auto-scaling value | 60 |
 
 ### Milvus Index Coordinator Deployment Configuration
 

--- a/charts/milvus/templates/datanode-hpa.yaml
+++ b/charts/milvus/templates/datanode-hpa.yaml
@@ -19,5 +19,5 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.dataNode.hpa.cpuUtilization | default 50 }}
+        averageUtilization: {{ .Values.dataNode.hpa.cpuUtilization | default 40 }}
 {{- end }}

--- a/charts/milvus/templates/indexnode-hpa.yaml
+++ b/charts/milvus/templates/indexnode-hpa.yaml
@@ -19,5 +19,5 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.indexNode.hpa.cpuUtilization | default 50 }}
+        averageUtilization: {{ .Values.indexNode.hpa.cpuUtilization | default 40 }}
 {{- end }}

--- a/charts/milvus/templates/proxy-hpa.yaml
+++ b/charts/milvus/templates/proxy-hpa.yaml
@@ -19,5 +19,5 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.proxy.hpa.cpuUtilization | default 50 }}
+        averageUtilization: {{ .Values.proxy.hpa.cpuUtilization | default 40 }}
 {{- end }}

--- a/charts/milvus/templates/querynode-hpa.yaml
+++ b/charts/milvus/templates/querynode-hpa.yaml
@@ -19,5 +19,11 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.queryNode.hpa.cpuUtilization | default 50 }}
+        averageUtilization: {{ .Values.queryNode.hpa.cpuUtilization | default 40 }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.queryNode.hpa.memoryUtilization | default 40 }}
 {{- end }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -392,7 +392,7 @@ queryNode:
     minReplicas: 1
     maxReplicas: 5
     cpuUtilization: 40
-    memoryUtilization: 40
+    memoryUtilization: 60
 
 indexCoordinator:
   enabled: false

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -392,6 +392,7 @@ queryNode:
     minReplicas: 1
     maxReplicas: 5
     cpuUtilization: 40
+    memoryUtilization: 40
 
 indexCoordinator:
   enabled: false


### PR DESCRIPTION
## What this PR does / why we need it:
Following @haorenfsa 's suggestion, I added a memory threshold for the query node.
https://github.com/zilliztech/milvus-helm/pull/188

And adjust the default values ​​of the hpa template to be consistent with README.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [v] Variables are documented in the README.md
- [v] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [v] PR only contains changes for one chart
