### PR TITLE
[milvus] added annotations to attu deployment and pod template

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.5.7"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.2.42
+version: 4.2.43
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/attu-deployment.yaml
+++ b/charts/milvus/templates/attu-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
 {{ include "milvus.labels" . | indent 4 }}
     component: "attu"
 {{ include "milvus.ud.labels" . | indent 4 }}
+    annotations:
+{{ include "milvus.ud.annotations" . | indent 4 }}
 spec:
   replicas: 1
   selector:
@@ -23,6 +25,11 @@ spec:
 {{- if .Values.attu.podLabels }}
 {{ toYaml .Values.attu.podLabels | indent 8 }}
 {{- end }}
+      annotations:
+      {{- if .Values.attu.podAnnotations }}
+        {{- toYaml .Values.attu.podAnnotations | nindent 8 }}
+      {{- end }}
+{{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
       {{- if .Values.attu.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/milvus/templates/attu-deployment.yaml
+++ b/charts/milvus/templates/attu-deployment.yaml
@@ -26,8 +26,8 @@ spec:
 {{ toYaml .Values.attu.podLabels | indent 8 }}
 {{- end }}
       annotations:
-      {{- if .Values.attu.podAnnotations }}
-        {{- toYaml .Values.attu.podAnnotations | nindent 8 }}
+      {{- if .Values.attu.annotations }}
+        {{- toYaml .Values.attu.annotations | nindent 8 }}
       {{- end }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -559,7 +559,7 @@ attu:
     # loadBalancerIP: ""
   resources: {}
   podLabels: {}
-  podAnnotations: {}
+  annotations: {}
   ingress:
     enabled: false
     ingressClassName: ""

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -559,6 +559,7 @@ attu:
     # loadBalancerIP: ""
   resources: {}
   podLabels: {}
+  podAnnotations: {}
   ingress:
     enabled: false
     ingressClassName: ""


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds the general `cluster.annotations` to attu deployment, to have feature parity with all the other deployments.
It also introduces `attu.annotations` for specific attu pod annotations.

it should fix #195 

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart

## General considerations
I tried to respect the existing naming convention, please let me know if I missed something.
I couldn't find the README file where attu variables are documented.