### PR TITLE
feat: support empty dir for streaming node when message type if woodpecker

### DIFF
--- a/charts/milvus/templates/streamingnode-deployment.yaml
+++ b/charts/milvus/templates/streamingnode-deployment.yaml
@@ -131,6 +131,10 @@ spec:
         {{- end }}
         - mountPath: /milvus/tools
           name: tools
+        {{- if .Values.woodpecker.enabled }}
+        - mountPath: /var/lib/milvus
+          name: woodpecker
+        {{- end }}
         {{- if .Values.volumeMounts }}
           {{- toYaml .Values.volumeMounts | nindent 8 }}
         {{- end}}
@@ -182,6 +186,10 @@ spec:
       {{- end }}
       - name: tools
         emptyDir: {}
+      {{- if .Values.woodpecker.enabled }}
+      - name: woodpecker
+        emptyDir: {}
+      {{- end }}
       {{- if .Values.volumes }}
         {{- toYaml .Values.volumes | nindent 6 }}
       {{- end}}


### PR DESCRIPTION


## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
