### PR TITLE
[milvus] Fix indentation of annotation in attu deployment

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.5.8"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.2.44
+version: 4.2.45
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/attu-deployment.yaml
+++ b/charts/milvus/templates/attu-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ include "milvus.labels" . | indent 4 }}
     component: "attu"
 {{ include "milvus.ud.labels" . | indent 4 }}
-    annotations:
+  annotations:
 {{ include "milvus.ud.annotations" . | indent 4 }}
 spec:
   replicas: 1


### PR DESCRIPTION
## What this PR does / why we need it:
Syntax error at metadata.annotations in attu deployment.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
