### PR TITLE
feat #216: add container security contex to all containers and init containers

### DIFF
--- a/charts/milvus/templates/attu-deployment.yaml
+++ b/charts/milvus/templates/attu-deployment.yaml
@@ -41,6 +41,14 @@ spec:
       - name: attu
         image: {{ .Values.attu.image.repository }}:{{ .Values.attu.image.tag }}
         imagePullPolicy: {{ .Values.attu.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.attu.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.attu.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.attu.containerSecurityContext | nindent 12 }}
+        {{ end }}
         ports:
         - name: attu
           containerPort: 3000

--- a/charts/milvus/templates/datacoord-deployment.yaml
+++ b/charts/milvus/templates/datacoord-deployment.yaml
@@ -62,6 +62,14 @@ spec:
         - "cp -r /opt/heaptrack /milvus/tools"
         image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.dataCoordinator.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.dataCoordinator.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.dataCoordinator.containerSecurityContext | nindent 12 }}
+        {{ end }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
@@ -87,6 +95,14 @@ spec:
         {{- if .Values.dataCoordinator.extraEnv }}
           {{- toYaml .Values.dataCoordinator.extraEnv | nindent 8 }}
         {{- end }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.dataCoordinator.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.dataCoordinator.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.dataCoordinator.containerSecurityContext | nindent 12 }}
+        {{ end }}
         ports:
           - name: datacoord
             containerPort: 13333

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -58,6 +58,14 @@ spec:
         - "cp -r /opt/heaptrack /milvus/tools"
         image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.dataNode.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.dataNode.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.dataNode.containerSecurityContext | nindent 12 }}
+        {{ end }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
@@ -66,6 +74,14 @@ spec:
       - name: datanode
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.dataNode.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.dataNode.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.dataNode.containerSecurityContext | nindent 12 }}
+        {{ end }}
         {{- if .Values.dataNode.heaptrack.enabled }}
         args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "datanode" ]
         {{- else }}

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -62,6 +62,14 @@ spec:
         - "cp -r /opt/heaptrack /milvus/tools"
         image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.indexCoordinator.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.indexCoordinator.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.indexCoordinator.containerSecurityContext | nindent 12 }}
+        {{ end }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
@@ -70,6 +78,14 @@ spec:
       - name: indexcoord
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.indexCoordinator.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.indexCoordinator.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.indexCoordinator.containerSecurityContext | nindent 12 }}
+        {{ end }}
         {{- if .Values.indexCoordinator.heaptrack.enabled }}
         args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "indexcoord" ]
         {{- else }}

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -57,6 +57,14 @@ spec:
         - "cp -r /opt/heaptrack /milvus/tools"
         image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.indexNode.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.indexNode.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.indexNode.containerSecurityContext | nindent 12 }}
+        {{ end }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
@@ -65,6 +73,14 @@ spec:
       - name: indexnode
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.indexNode.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.indexNode.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.indexNode.containerSecurityContext | nindent 12 }}
+        {{ end }}
         {{- if .Values.indexNode.heaptrack.enabled }}
         args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "indexnode" ]
         {{- else }}

--- a/charts/milvus/templates/mixcoord-deployment.yaml
+++ b/charts/milvus/templates/mixcoord-deployment.yaml
@@ -62,6 +62,14 @@ spec:
         - "cp -r /opt/heaptrack /milvus/tools"
         image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.mixCoordinator.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.mixCoordinator.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.mixCoordinator.containerSecurityContext | nindent 12 }}
+        {{ end }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
@@ -70,6 +78,14 @@ spec:
       - name: mixcoord
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.mixCoordinator.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.mixCoordinator.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.mixCoordinator.containerSecurityContext | nindent 12 }}
+        {{ end }}
         {{- if .Values.mixCoordinator.heaptrack.enabled }}
         args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "mixture", "-rootcoord", "-querycoord", "-datacoord", "-indexcoord" ]
         {{- else }}

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -58,6 +58,14 @@ spec:
         - "cp -r /opt/heaptrack /milvus/tools"
         image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.proxy.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.proxy.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.proxy.containerSecurityContext | nindent 12 }}
+        {{ end }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
@@ -66,6 +74,14 @@ spec:
       - name: proxy
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.proxy.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.proxy.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.proxy.containerSecurityContext | nindent 12 }}
+        {{ end }}
         {{- if .Values.proxy.heaptrack.enabled }}
         args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "proxy" ]
         {{- else }}

--- a/charts/milvus/templates/querycoord-deployment.yaml
+++ b/charts/milvus/templates/querycoord-deployment.yaml
@@ -62,6 +62,14 @@ spec:
         - "cp -r /opt/heaptrack /milvus/tools"
         image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.queryCoordinator.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.queryCoordinator.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.queryCoordinator.containerSecurityContext | nindent 12 }}
+        {{ end }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
@@ -70,6 +78,14 @@ spec:
       - name: querycoord
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.queryCoordinator.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.queryCoordinator.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.queryCoordinator.containerSecurityContext | nindent 12 }}
+        {{ end }}
         {{- if .Values.queryCoordinator.heaptrack.enabled }}
         args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "querycoord" ]
         {{- else }}

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -57,6 +57,14 @@ spec:
         - "cp -r /opt/heaptrack /milvus/tools"
         image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.queryNode.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.queryNode.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.queryNode.containerSecurityContext | nindent 12 }}
+        {{ end }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
@@ -65,6 +73,14 @@ spec:
       - name: querynode
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.queryNode.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.queryNode.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.queryNode.containerSecurityContext | nindent 12 }}
+        {{ end }}
         {{- if .Values.queryNode.heaptrack.enabled }}
         args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "querynode" ]
         {{- else }}

--- a/charts/milvus/templates/rootcoord-deployment.yaml
+++ b/charts/milvus/templates/rootcoord-deployment.yaml
@@ -62,6 +62,14 @@ spec:
         - "cp -r /opt/heaptrack /milvus/tools"
         image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.rootCoordinator.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.rootCoordinator.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.rootCoordinator.containerSecurityContext | nindent 12 }}
+        {{ end }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
@@ -70,6 +78,14 @@ spec:
       - name: rootcoord
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.rootCoordinator.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.rootCoordinator.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.rootCoordinator.containerSecurityContext | nindent 12 }}
+        {{ end }}
         {{- if .Values.rootCoordinator.heaptrack.enabled }}
         args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "rootcoord" ]
         {{- else }}

--- a/charts/milvus/templates/standalone-deployment.yaml
+++ b/charts/milvus/templates/standalone-deployment.yaml
@@ -50,6 +50,14 @@ spec:
         - "cp -r /opt/heaptrack /milvus/tools"
         image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.standalone.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.standalone.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.standalone.containerSecurityContext | nindent 12 }}
+        {{ end }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
@@ -58,6 +66,14 @@ spec:
       - name: standalone
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.standalone.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.standalone.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.standalone.containerSecurityContext | nindent 12 }}
+        {{ end }}
         {{- if .Values.standalone.heaptrack.enabled }}
         args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "standalone" ]
         {{- else }}

--- a/charts/milvus/templates/streamingnode-deployment.yaml
+++ b/charts/milvus/templates/streamingnode-deployment.yaml
@@ -55,6 +55,14 @@ spec:
         - "cp -r /opt/heaptrack /milvus/tools"
         image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.streamingNode.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.streamingNode.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.streamingNode.containerSecurityContext | nindent 12 }}
+        {{ end }}
         volumeMounts:
         - mountPath: /milvus/tools
           name: tools
@@ -63,6 +71,14 @@ spec:
       - name: streamingnode
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.streamingNode.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.streamingNode.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.streamingNode.containerSecurityContext | nindent 12 }}
+        {{ end }}
         {{- if .Values.streamingNode.heaptrack.enabled }}
         args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "streamingnode" ]
         {{- else }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -42,6 +42,7 @@ affinity: {}
 # Global securityContext
 # If set, this will apply to all milvus components
 # Individual components can be set to a different securityContext
+containerSecurityContext: {}
 securityContext: {}
   # runAsUser: 1000
   # runAsGroup: 1000
@@ -238,6 +239,7 @@ standalone:
   affinity: {}
   tolerations: []
   securityContext: {}
+  containerSecurityContext: {}
   topologySpreadConstraints: []  # Component specific topologySpreadConstraints
   extraEnv: []
   heaptrack:
@@ -282,6 +284,7 @@ proxy:
   affinity: {}
   tolerations: []
   securityContext: {}
+  containerSecurityContext: {}
   topologySpreadConstraints: []  # Component specific topologySpreadConstraints
   extraEnv: []
   heaptrack:
@@ -327,6 +330,7 @@ rootCoordinator:
   affinity: {}
   tolerations: []
   securityContext: {}
+  containerSecurityContext: {}
   topologySpreadConstraints: []  # Component specific topologySpreadConstraints
   extraEnv: []
   heaptrack:
@@ -355,6 +359,7 @@ queryCoordinator:
   affinity: {}
   tolerations: []
   securityContext: {}
+  containerSecurityContext: {}
   topologySpreadConstraints: []  # Component specific topologySpreadConstraints
   extraEnv: []
   heaptrack:
@@ -387,6 +392,7 @@ queryNode:
   affinity: {}
   tolerations: []
   securityContext: {}
+  containerSecurityContext: {}
   topologySpreadConstraints: []  # Component specific topologySpreadConstraints
   extraEnv: []
   heaptrack:
@@ -417,6 +423,7 @@ indexCoordinator:
   affinity: {}
   tolerations: []
   securityContext: {}
+  containerSecurityContext: {}
   topologySpreadConstraints: []  # Component specific topologySpreadConstraints
   extraEnv: []
   heaptrack:
@@ -448,6 +455,7 @@ indexNode:
   affinity: {}
   tolerations: []
   securityContext: {}
+  containerSecurityContext: {}
   topologySpreadConstraints: []  # Component specific topologySpreadConstraints
   extraEnv: []
   heaptrack:
@@ -477,6 +485,7 @@ dataCoordinator:
   affinity: {}
   tolerations: []
   securityContext: {}
+  containerSecurityContext: {}
   topologySpreadConstraints: []  # Component specific topologySpreadConstraints
   extraEnv: []
   heaptrack:
@@ -505,6 +514,7 @@ dataNode:
   affinity: {}
   tolerations: []
   securityContext: {}
+  containerSecurityContext: {}
   topologySpreadConstraints: []  # Component specific topologySpreadConstraints
   extraEnv: []
   heaptrack:
@@ -532,6 +542,7 @@ mixCoordinator:
   affinity: {}
   tolerations: []
   securityContext: {}
+  containerSecurityContext: {}
   topologySpreadConstraints: []  # Component specific topologySpreadConstraints
   extraEnv: []
   heaptrack:
@@ -557,6 +568,7 @@ streamingNode:
   affinity: {}
   tolerations: []
   securityContext: {}
+  containerSecurityContext: {}
   extraEnv: []
   heaptrack:
     enabled: false
@@ -579,6 +591,7 @@ attu:
     # loadBalancerIP: ""
   resources: {}
   securityContext: {}
+  containerSecurityContext: {}
   podLabels: {}
   annotations: {}
   ingress:


### PR DESCRIPTION
## What this PR does / why we need it:
To give the option to define a container security context, at component level or define a general one. The same that it's currently done with the pod security context. 
Closes #216.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
