### PR TITLE
fixes #220: Adds runtimeClassName option to query and index deployments

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.5.12"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.2.50
+version: 4.2.51
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -42,6 +42,9 @@ spec:
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
       serviceAccountName: {{ include "milvus.serviceAccount" . }}
+      {{- if .Values.indexNode.runtimeClassName }}
+      runtimeClassName: {{ .Values.indexNode.runtimeClassName }}
+      {{- end }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -42,6 +42,9 @@ spec:
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
       serviceAccountName: {{ include "milvus.serviceAccount" . }}
+      {{- if .Values.queryNode.runtimeClassName }}
+      runtimeClassName: {{ .Values.queryNode.runtimeClassName }}
+      {{- end }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -388,6 +388,8 @@ queryNode:
   # resources:
   #   limits:
   #     ephemeral-storage: 100Gi
+  # Set below when using other runtimes than default like nvidia for example
+  runtimeClassName: ""
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -451,6 +453,8 @@ indexNode:
   # Set local storage size in resources
   # limits:
   #    ephemeral-storage: 100Gi
+  # Set below when using other runtimes than default like nvidia for example
+  runtimeClassName: ""
   nodeSelector: {}
   affinity: {}
   tolerations: []


### PR DESCRIPTION
This PR introduces the `runtimeClassName` field to the `query` and `index` deployments in the Milvus Helm chart.

- Adds `.Values.queryNode.runtimeClassName` and `.Values.indexNode.runtimeClassName` support
- Bumps the chart version in `Chart.yaml`
- Allows users to configure custom `RuntimeClass` (e.g., for nvidia or kata etc)
Fixes: #220
