### PR TITLE
[tei] fix: correct indentation for extraEnv and volumeMounts using nindent

### DIFF
--- a/charts/tei/templates/statefulset.yaml
+++ b/charts/tei/templates/statefulset.yaml
@@ -56,13 +56,13 @@ spec:
           {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.extraEnv }}
         env:
-          {{ toYaml .Values.extraEnv | indent 8 }}
+          {{ toYaml .Values.extraEnv | nindent 8 }}
         {{- end }}
         volumeMounts:
         - name: data-volume
           mountPath: {{ .Values.persistence.mountPath }}
         {{- if .Values.volumeMounts }}
-          {{ toYaml .Values.volumeMounts | indent 8 }}
+          {{ toYaml .Values.volumeMounts | nindent 8 }}
         {{- end }}
       volumes:
       {{- if not .Values.persistence.enabled }}


### PR DESCRIPTION
Replaced `indent` with `nindent` in Helm templates for:
- `extraEnv` variables
- `volumeMounts` declarations

Ensures proper YAML formatting by:
1. Starting blocks on new lines
2. Maintaining consistent 8-space indentation
3. Preventing indentation errors in generated manifests

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
