### PR TITLE
[milvus] -  Add OpenShift route support for Attu UI

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.5.13"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.2.51
+version: 4.2.52
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -267,6 +267,12 @@ The following table lists the configurable parameters of the Milvus Service and 
 | Parameter                                 | Description                                   | Default                                                 |
 |-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
 | `cluster.enabled`                         | Enable or disable Milvus Cluster mode         | `true`                                                 |
+| `route.enabled`                           | Enable OpenShift route                        | `false`                                                |
+| `route.hostname`                          | Hostname for the OpenShift route             | `""`                                                   |
+| `route.path`                             | Path for the OpenShift route                 | `""`                                                   |
+| `route.termination`                       | TLS termination for the route                | `edge`                                                 |
+| `route.annotations`                       | Route annotations                            | `{}`                                                   |
+| `route.labels`                           | Route labels                                 | `{}`                                                   |
 | `image.all.repository`                    | Image repository                              | `milvusdb/milvus`                                       |
 | `image.all.tag`                           | Image tag                                     | `v2.5.13`                           |
 | `image.all.pullPolicy`                    | Image pull policy                             | `IfNotPresent`                                          |

--- a/charts/milvus/templates/attu-route.yaml
+++ b/charts/milvus/templates/attu-route.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.attu.enabled .Values.attu.route.enabled }}
+{{- $attuServiceName := include "milvus.attu.fullname" . -}}
+{{- $attuServicePort := .Values.attu.service.port -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "milvus.attu.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "milvus.labels" . | indent 4 }}
+{{- if .Values.attu.route.labels }}
+{{ toYaml .Values.attu.route.labels | indent 4 }}
+{{- end }}
+{{- with .Values.attu.route.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  {{- if .Values.attu.route.host }}
+  host: {{ .Values.attu.route.host }}
+  {{- end }}
+  port:
+    targetPort: {{ $attuServicePort }}
+  to:
+    kind: Service
+    name: {{ $attuServiceName }}
+    weight: 100
+  {{- if .Values.attu.route.tls }}
+  tls:
+    {{- toYaml .Values.attu.route.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -607,6 +607,19 @@ attu:
     #  - secretName: chart-attu-tls
     #    hosts:
     #      - milvus-attu.local
+  
+  route:
+    enabled: false
+    host: ""
+    annotations: {}
+    labels: {}
+    tls:
+      termination: edge  # edge, passthrough, or reencrypt
+      insecureEdgeTerminationPolicy: Redirect  # None, Redirect, or Allow
+      # certificate: ""
+      # key: ""
+      # caCertificate: ""
+      # destinationCACertificate: ""
 
 
 ## Configuration values for the minio dependency


### PR DESCRIPTION
## What this PR does / why we need it:

### Why
OpenShift users currently have to use Kubernetes Ingress to expose the Attu UI interface. While this works, OpenShift Routes can be the preferred way to expose services in OpenShift environments, offering:
- Built-in TLS termination and certificate management
- Integration with OpenShift's certificate management
- Native support for OpenShift's security features
- Better integration with OpenShift's routing layer

### What
This PR introduces OpenShift Route support as an alternative to Kubernetes Ingress for the Attu UI interface. Users can now choose between:
1. Using Kubernetes Ingress (existing behavior)
2. Using OpenShift Route (new feature)

The implementation is non-breaking and opt-in, maintaining compatibility with existing deployments. Route configuration supports all major features including:
- Custom hostname configuration
- Multiple TLS termination options (edge, passthrough, reencrypt)
- Insecure traffic policy management
- Custom annotations and labels

### How to Use
Enable the Route in values.yaml:
```yaml
attu:
  route:
    enabled: true
    host: "your-attu-host.apps.example.com"  # Optional
    tls:
      termination: edge
```

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
