### PR TITLE
fixes #220: Adds runtimeClassName option to query and index deployments

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.5.14"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.2.55
+version: 4.2.56
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -42,6 +42,9 @@ spec:
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
       serviceAccountName: {{ include "milvus.serviceAccount" . }}
+      {{- if .Values.indexNode.runtimeClassName }}
+      runtimeClassName: {{ .Values.indexNode.runtimeClassName }}
+      {{- end }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -42,6 +42,9 @@ spec:
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
       serviceAccountName: {{ include "milvus.serviceAccount" . }}
+      {{- if .Values.queryNode.runtimeClassName }}
+      runtimeClassName: {{ .Values.queryNode.runtimeClassName }}
+      {{- end }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -388,6 +388,8 @@ queryNode:
   # resources:
   #   limits:
   #     ephemeral-storage: 100Gi
+  # Set below when using other runtimes than default like nvidia for example
+  runtimeClassName: ""
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -451,6 +453,8 @@ indexNode:
   # Set local storage size in resources
   # limits:
   #    ephemeral-storage: 100Gi
+  # Set below when using other runtimes than default like nvidia for example
+  runtimeClassName: ""
   nodeSelector: {}
   affinity: {}
   tolerations: []


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds `runtimeClassName` as an optional configuration for the `queryNode` and `indexNode` deployments. This allows users to specify alternate runtimes, such as NVIDIA's runtime for GPU workloads.

This is a replacement for #221. It is rebased onto the latest upstream `master`, includes the proper chart version bump to `4.2.56`, and has the correct DCO sign-off to satisfy contribution requirements.

This PR will close #220.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart