### PR TITLE
 [milvus] Update default etcd image 3.5.21-r2 and bump chart version to 4.2.56 

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.5.14"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.2.55
+version: 4.2.56
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -695,7 +695,7 @@ etcd:
     create: false
   image:
     repository: "milvusdb/etcd"
-    tag: "3.5.18-r1"
+    tag: "3.5.21-r2"
     pullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
Bump etcd [#17](https://github.com/milvus-io/bitnami-docker-etcd/issues/17)


## Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
