### PR TITLE
update bitnami image to use legacy bitnami repo

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.6.0"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 5.0.0
+version: 5.0.1
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -1206,8 +1206,8 @@ kafka:
   name: kafka
   replicaCount: 3
   image:
-    repository: bitnami/kafka
-    tag: 3.1.0-debian-10-r52
+    repository: bitnamilegacy/kafka
+    tag: 3.1.0
   ## Increase graceful termination for kafka graceful shutdown
   terminationGracePeriodSeconds: "90"
   pdb:
@@ -1248,15 +1248,15 @@ kafka:
     kafka:
       enabled: false
       image:
-        repository: bitnami/kafka-exporter-archived
-        tag: 1.4.2-debian-10-r182
+        repository: bitnamilegacy/kafka-exporter-archived
+        tag: 1.4.2
 
     ## Prometheus JMX exporter: exposes the majority of Kafkas metrics
     jmx:
       enabled: false
       image:
-        repository: bitnami/jmx-exporter
-        tag: 0.16.1-debian-10-r245
+        repository: bitnamilegacy/jmx-exporter
+        tag: 0.16.1
 
     ## To enable serviceMonitor, you must enable either kafka exporter or jmx exporter.
     ## And you can enable them both
@@ -1271,6 +1271,9 @@ kafka:
   zookeeper:
     enabled: true
     replicaCount: 3
+    image: 
+      repository: bitnamilegacy/zookeeper
+      tag: 3.7.0
 
 ###################################
 # Woodpecker


### PR DESCRIPTION
This pull request updates the Milvus Helm chart dependencies to use images from the `bitnamilegacy` repository instead of the standard `bitnami` repository, and bumps the chart version. These changes ensure continued access to required container images and improve compatibility.

Dependency image repository updates:

* Changed the Kafka image repository from `bitnami/kafka` to `bitnamilegacy/kafka` and updated the tag to `3.1.0` in `values.yaml`.
* Updated Kafka exporter and JMX exporter image repositories from `bitnami` to `bitnamilegacy` and adjusted tags accordingly in `values.yaml`.
* Set Zookeeper image to `bitnamilegacy/zookeeper` with tag `3.7.0` in `values.yaml`.

Chart version bump:

* Increased the chart version from `5.0.0` to `5.0.1` in `Chart.yaml` to reflect these dependency updates.