### PR TITLE
[milvus] Add terminationGracePeriodSeconds to milvus components

### DIFF
--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -428,6 +428,7 @@ The following table lists the configurable parameters of the Milvus Standalone c
 | `standalone.persistence.persistentVolumeClaim.accessModes` | The Milvus standalone data Persistence access modes | `ReadWriteOnce`                  |
 | `standalone.persistence.persistentVolumeClaim.size` | The size of Milvus standalone data Persistent Volume Storage Class | `5Gi`                    |
 | `standalone.persistence.persistentVolumeClaim.subPath` | SubPath for Milvus standalone data mount | `unset`                                         |
+| `standalone.terminationGracePeriodSeconds`  | Deployment terminationGracePeriodSeconds | `` |
 
 ### Milvus Proxy Deployment Configuration
 
@@ -450,6 +451,7 @@ The following table lists the configurable parameters of the Milvus Proxy compon
 | `proxy.http.debugMode.enabled`            | Enable debug mode for rest api                          | `false`       |
 | `proxy.tls.enabled`                       | Enable porxy tls connection                             | `false`       |
 | `proxy.strategy`                          | Deployment strategy configuration                       | RollingUpdate |
+| `proxy.terminationGracePeriodSeconds`     | Deployment terminationGracePeriodSeconds                | ``            |
 | `proxy.annotations`                       | Additional pod annotations                              | `{}`          |
 | `proxy.hpa` | Enable hpa for proxy node | false |
 | `proxy.minReplicas` | Specify the minimum number of replicas | 1 |
@@ -475,6 +477,7 @@ The following table lists the configurable parameters of the Milvus Query Node c
 | `queryNode.profiling.enabled`             | Whether to enable live profiling                   | `false`                                          |
 | `queryNode.extraEnv`                      | Additional Milvus Query Node container environment variables | `[]`                                     |
 | `queryNode.strategy`                      | Deployment strategy configuration |  RollingUpdate                                         |
+| `queryNode.terminationGracePeriodSeconds`  | Deployment terminationGracePeriodSeconds | `` |
 | `queryNode.annotations`                    | Additional pod annotations | `{}` |
 | `queryNode.hpa` | Enable hpa for query node | false |
 | `queryNode.minReplicas` | Specify the minimum number of replicas | 1 |
@@ -502,6 +505,7 @@ The following table lists the configurable parameters of the Milvus Data Node co
 | `dataNode.profiling.enabled`              | Whether to enable live profiling                   | `false`                                          |
 | `dataNode.extraEnv`                       | Additional Milvus Data Node container environment variables | `[]`                                      |
 | `dataNode.strategy`                       | Deployment strategy configuration |  RollingUpdate                                         |
+| `dataNode.terminationGracePeriodSeconds`  | Deployment terminationGracePeriodSeconds | `` |
 | `dataNode.annotations`                    | Additional pod annotations | `{}` |
 | `dataNode.hpa` | Enable hpa for data node | false |
 | `dataNode.minReplicas` | Specify the minimum number of replicas | 1 |
@@ -532,6 +536,7 @@ The following table lists the configurable parameters of the Milvus Mix Coordina
 | `mixCoordinator.service.loadBalancerSourceRanges`    | List of IP CIDRs allowed access to lb (if supported) | `[]`                                 |
 | `mixCoordinator.service.externalIPs`                 | Service external IP addresses                 | `[]`                                        |
 | `mixCoordinator.strategy`                       | Deployment strategy configuration |  RollingUpdate                                         |
+| `mixCoordinator.terminationGracePeriodSeconds`  | Deployment terminationGracePeriodSeconds | `` |
 | `mixCoordinator.annotations`                    | Additional pod annotations | `{}` |
 
 ### Milvus Streaming Node Deployment Configuration
@@ -552,6 +557,7 @@ The following table lists the configurable parameters of the Milvus Streaming No
 | `streamingNode.profiling.enabled`         | Whether to enable live profiling                       | `false`       |
 | `streamingNode.extraEnv`                  | Additional Milvus Streaming Node container environment variables | `[]`  |
 | `streamingNode.strategy`                  | Deployment strategy configuration                       | `{}`          |
+| `streamingNode.terminationGracePeriodSeconds`  | Deployment terminationGracePeriodSeconds | `` |
 | `streamingNode.woodpecker.embedded`       | Whether to use embedded Woodpecker in Streaming Node. When `false`, external Woodpecker is used and `woodpecker.enabled` must be set to `true` | `true`        |
 | `streamingNode.woodpecker.storage.type`   | Woodpecker storage type. Valid values: `minio`, `local`. Only applies when `embedded` is `true` | `minio`       |
 

--- a/charts/milvus/templates/attu-deployment.yaml
+++ b/charts/milvus/templates/attu-deployment.yaml
@@ -89,4 +89,10 @@ spec:
       securityContext:
 {{ toYaml .Values.attu.securityContext | indent 8 }}
     {{- end }}
+    {{- if and (.Values.terminationGracePeriodSeconds) (not .Values.attu.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end }}
+    {{- if .Values.attu.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.attu.terminationGracePeriodSeconds }}
+    {{- end }}
 {{- end }}

--- a/charts/milvus/templates/datacoord-deployment.yaml
+++ b/charts/milvus/templates/datacoord-deployment.yaml
@@ -201,7 +201,12 @@ spec:
       securityContext:
 {{ toYaml .Values.dataCoordinator.securityContext | indent 8 }}
     {{- end }}
-
+    {{- if and (.Values.terminationGracePeriodSeconds) (not .Values.dataCoordinator.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end }}
+    {{- if .Values.dataCoordinator.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.dataCoordinator.terminationGracePeriodSeconds }}
+    {{- end }}
       volumes:
       - name: milvus-config
         configMap:

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -192,6 +192,12 @@ spec:
       securityContext:
 {{ toYaml .Values.dataNode.securityContext | indent 8 }}
     {{- end }}
+    {{- if and (.Values.terminationGracePeriodSeconds) (not .Values.dataNode.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end }}
+    {{- if .Values.dataNode.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.dataNode.terminationGracePeriodSeconds }}
+    {{- end }}
       volumes:
       - name: milvus-config
         configMap:

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -201,6 +201,12 @@ spec:
       securityContext:
 {{ toYaml .Values.indexCoordinator.securityContext | indent 8 }}
     {{- end }}
+    {{- if and (.Values.terminationGracePeriodSeconds) (not .Values.indexCoordinator.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end }}
+    {{- if .Values.indexCoordinator.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.indexCoordinator.terminationGracePeriodSeconds }}
+    {{- end }}
 
       volumes:
       - name: milvus-config

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -210,6 +210,12 @@ spec:
       securityContext:
 {{ toYaml .Values.indexNode.securityContext | indent 8 }}
     {{- end }}
+    {{- if and (.Values.terminationGracePeriodSeconds) (not .Values.indexNode.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end }}
+    {{- if .Values.indexNode.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.indexNode.terminationGracePeriodSeconds }}
+    {{- end }}
 
       volumes:
       - name: milvus-config

--- a/charts/milvus/templates/mixcoord-deployment.yaml
+++ b/charts/milvus/templates/mixcoord-deployment.yaml
@@ -194,6 +194,12 @@ spec:
       securityContext:
 {{ toYaml .Values.mixCoordinator.securityContext | indent 8 }}
     {{- end }}
+    {{- if and (.Values.terminationGracePeriodSeconds) (not .Values.mixCoordinator.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end }}
+    {{- if .Values.mixCoordinator.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.mixCoordinator.terminationGracePeriodSeconds }}
+    {{- end }}
 
       volumes:
       - name: milvus-config

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -196,6 +196,12 @@ spec:
       securityContext:
 {{ toYaml .Values.proxy.securityContext | indent 8 }}
     {{- end }}
+    {{- if and (.Values.terminationGracePeriodSeconds) (not .Values.proxy.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end }}
+    {{- if .Values.proxy.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.proxy.terminationGracePeriodSeconds }}
+    {{- end }}
 
       volumes:
       - name: milvus-config

--- a/charts/milvus/templates/querycoord-deployment.yaml
+++ b/charts/milvus/templates/querycoord-deployment.yaml
@@ -201,6 +201,12 @@ spec:
       securityContext:
 {{ toYaml .Values.queryCoordinator.securityContext | indent 8 }}
     {{- end }}
+    {{- if and (.Values.terminationGracePeriodSeconds) (not .Values.queryCoordinator.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end }}
+    {{- if .Values.queryCoordinator.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.queryCoordinator.terminationGracePeriodSeconds }}
+    {{- end }}
 
       volumes:
       - name: milvus-config

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -220,6 +220,12 @@ spec:
       securityContext:
 {{ toYaml .Values.queryNode.securityContext | indent 8 }}
     {{- end }}
+    {{- if and (.Values.terminationGracePeriodSeconds) (not .Values.queryNode.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end }}
+    {{- if .Values.queryNode.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.queryNode.terminationGracePeriodSeconds }}
+    {{- end }}
 
       volumes:
       - name: milvus-config

--- a/charts/milvus/templates/rootcoord-deployment.yaml
+++ b/charts/milvus/templates/rootcoord-deployment.yaml
@@ -201,6 +201,12 @@ spec:
       securityContext:
 {{ toYaml .Values.rootCoordinator.securityContext | indent 8 }}
     {{- end }}
+    {{- if and (.Values.terminationGracePeriodSeconds) (not .Values.rootCoordinator.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end }}
+    {{- if .Values.rootCoordinator.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.rootCoordinator.terminationGracePeriodSeconds }}
+    {{- end }}
 
       volumes:
       - name: milvus-config

--- a/charts/milvus/templates/standalone-deployment.yaml
+++ b/charts/milvus/templates/standalone-deployment.yaml
@@ -199,6 +199,12 @@ spec:
       securityContext:
 {{ toYaml .Values.standalone.securityContext | indent 8 }}
     {{- end }}
+    {{- if and (.Values.terminationGracePeriodSeconds) (not .Values.standalone.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end }}
+    {{- if .Values.standalone.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.standalone.terminationGracePeriodSeconds }}
+    {{- end }}
 
       volumes:
       - emptyDir: {}

--- a/charts/milvus/templates/streamingnode-deployment.yaml
+++ b/charts/milvus/templates/streamingnode-deployment.yaml
@@ -207,6 +207,13 @@ spec:
       securityContext:
 {{ toYaml .Values.streamingNode.securityContext | indent 8 }}
     {{- end }}
+    {{- if and (.Values.terminationGracePeriodSeconds) (not .Values.streamingNode.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end }}
+    {{- if .Values.streamingNode.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.streamingNode.terminationGracePeriodSeconds }}
+    {{- end }}
+
       volumes:
       - name: milvus-config
         configMap:

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -51,6 +51,12 @@ securityContext: {}
   # fsGroup: 1000
   # runAsNonRoot: true
 
+# Global terminationGracePeriodSeconds
+# If set, this will apply to all milvus components
+# Individual components can be set to a different terminationGracePeriodSeconds
+# ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination-flow
+terminationGracePeriodSeconds: ""
+
 # Global topologySpreadConstraints
 # If set, this will apply to all milvus components
 # Individual components can be set to different topologySpreadConstraints
@@ -245,6 +251,7 @@ standalone:
   securityContext: {}
   containerSecurityContext: {}
   topologySpreadConstraints: []  # Component specific topologySpreadConstraints
+  terminationGracePeriodSeconds: ""
   extraEnv: []
   heaptrack:
     enabled: false
@@ -318,6 +325,7 @@ proxy:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  terminationGracePeriodSeconds: ""
   annotations: {}
   hpa:
     enabled: false
@@ -346,6 +354,7 @@ rootCoordinator:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  terminationGracePeriodSeconds: ""
   annotations: {}
 
   service:
@@ -375,6 +384,7 @@ queryCoordinator:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  terminationGracePeriodSeconds: ""
   annotations: {}
 
   service:
@@ -412,6 +422,7 @@ queryNode:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  terminationGracePeriodSeconds: ""
   annotations: {}
   hpa:
     enabled: false
@@ -441,6 +452,7 @@ indexCoordinator:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  terminationGracePeriodSeconds: ""
   annotations: {}
 
   service:
@@ -477,6 +489,7 @@ indexNode:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  terminationGracePeriodSeconds: ""
   annotations: {}
   hpa:
     enabled: false
@@ -505,6 +518,7 @@ dataCoordinator:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  terminationGracePeriodSeconds: ""
   annotations: {}
 
   service:
@@ -532,6 +546,7 @@ dataNode:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  terminationGracePeriodSeconds: ""
   annotations: {}
   hpa:
     enabled: false
@@ -562,6 +577,7 @@ mixCoordinator:
   # Deployment strategy, default is RollingUpdate
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
   strategy: {}
+  terminationGracePeriodSeconds: ""
   annotations: {}
 
   service:
@@ -583,6 +599,7 @@ streamingNode:
   profiling:
     enabled: false  # Enable live profiling
   strategy: {}
+  terminationGracePeriodSeconds: ""
 
 cdc:
   enabled: false
@@ -618,6 +635,7 @@ attu:
   resources: {}
   securityContext: {}
   containerSecurityContext: {}
+  terminationGracePeriodSeconds: ""
   podLabels: {}
   annotations: {}
   ingress:


### PR DESCRIPTION
## What this PR does / why we need it:

When upgrading/restarting a milvus cluster deployed with this helm chart, the default 30s value for _terminationGracePeriodSeconds_ can be too short to allow the data loaded in terminating querynodes to be migrated to running nodes, leading to failed searches.

This PR lets users tune this value to ensure upgrades without interruption of the search service.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
