### PR TITLE
[milvus] Add cdc component

### DIFF
--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -555,6 +555,28 @@ The following table lists the configurable parameters of the Milvus Streaming No
 | `streamingNode.extraEnv`                  | Additional Milvus Streaming Node container environment variables | `[]`  |
 | `streamingNode.strategy`                  | Deployment strategy configuration                       | `{}`          |
 
+### Milvus CDC Deployment Configuration
+
+The following table lists the configurable parameters of the Milvus CDC (Change Data Capture) component and their default values. CDC is a new component introduced in Milvus v2.6.6+ that captures and replicates data changes within Milvus.
+
+| Parameter                                 | Description                                             | Default       |
+|-------------------------------------------|---------------------------------------------------------|---------------|
+| `cdc.enabled`                             | Enable or disable CDC component                         | `false`       |
+| `cdc.replicas`                            | Desired number of CDC pods                              | `1`           |
+| `cdc.resources`                           | Resource requests/limits for the Milvus CDC pods       | `{}`          |
+| `cdc.nodeSelector`                        | Node labels for Milvus CDC pods assignment             | `{}`          |
+| `cdc.affinity`                             | Affinity settings for Milvus CDC pods assignment        | `{}`          |
+| `cdc.tolerations`                          | Toleration labels for Milvus CDC pods assignment       | `[]`          |
+| `cdc.securityContext`                      | Security context for CDC pods                          | `{}`          |
+| `cdc.containerSecurityContext`            | Container security context for CDC                      | `{}`          |
+| `cdc.topologySpreadConstraints`           | Topology spread constraints for CDC pods                | `[]`          |
+| `cdc.heaptrack.enabled`                   | Whether to enable heaptrack                             | `false`       |
+| `cdc.profiling.enabled`                   | Whether to enable live profiling                        | `false`       |
+| `cdc.extraEnv`                             | Additional Milvus CDC container environment variables   | `[]`          |
+| `cdc.strategy`                             | Deployment strategy configuration                       | `{}`          |
+| `cdc.annotations`                          | Additional pod annotations                              | `{}`          |
+
+> **Note**: Currently, CDC only supports one replica. Setting `cdc.replicas` to a value greater than 1 is not recommended.
 
 ### TEI Configuration
 

--- a/charts/milvus/templates/_helpers.tpl
+++ b/charts/milvus/templates/_helpers.tpl
@@ -113,6 +113,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a default fully qualified CDC name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "milvus.cdc.fullname" -}}
+{{ template "milvus.fullname" . }}-cdc
+{{- end -}}
+
+{{/*
 Create a default fully qualified pulsar name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/milvus/templates/cdc-deployment.yaml
+++ b/charts/milvus/templates/cdc-deployment.yaml
@@ -1,0 +1,208 @@
+{{- if .Values.cdc.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "milvus.cdc.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "milvus.labels" . | indent 4 }}
+    component: "cdc"
+{{ include "milvus.ud.labels" . | indent 4 }}
+  annotations:
+{{ include "milvus.ud.annotations" . | indent 4 }}
+
+spec:
+  {{- if ge (int .Values.cdc.replicas) 0 }}
+  replicas: {{ .Values.cdc.replicas }}
+  {{- end }}
+  {{- with .Values.cdc.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+{{ include "milvus.matchLabels" . | indent 6 }}
+      component: "cdc"
+  template:
+    metadata:
+      labels:
+{{ include "milvus.matchLabels" . | indent 8 }}
+        component: "cdc"
+{{ include "milvus.ud.labels" . | indent 8 }}
+      annotations:
+      {{- if .Values.cdc.profiling.enabled }}
+        pyroscope.io/scrape: "true"
+        pyroscope.io/application-name: {{ template "milvus.cdc.fullname" . }}
+        pyroscope.io/port: "9091"
+      {{- end }}
+      {{- if .Values.cdc.annotations }}
+        {{- toYaml .Values.cdc.annotations | nindent 8 }}
+      {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{ include "milvus.ud.annotations" . | indent 8 }}
+    spec:
+      serviceAccountName: {{ include "milvus.serviceAccount" . }}
+      {{- if .Values.image.all.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.all.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      initContainers:
+      {{- if .Values.cdc.heaptrack.enabled }}
+      - name: heaptrack
+        command:
+        - /bin/bash
+        - -c
+        - "cp -r /opt/heaptrack /milvus/tools"
+        image: "{{ .Values.heaptrack.image.repository }}:{{ .Values.heaptrack.image.tag }}"
+        imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.cdc.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.cdc.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.cdc.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        volumeMounts:
+        - mountPath: /milvus/tools
+          name: tools
+      {{- end }}
+      containers:
+      - name: cdc
+        image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
+        imagePullPolicy: {{ .Values.image.all.pullPolicy }}
+        {{ if and (.Values.containerSecurityContext) (not .Values.cdc.containerSecurityContext) }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{ if .Values.cdc.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.cdc.containerSecurityContext | nindent 12 }}
+        {{ end }}
+        {{- if .Values.cdc.heaptrack.enabled }}
+        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "cdc" ]
+        {{- else }}
+        args: [ "milvus", "run", "cdc" ]
+        {{- end }}
+        env:
+        {{- if .Values.cdc.heaptrack.enabled }}
+        - name: LD_LIBRARY_PATH
+          value: /milvus/tools/heaptrack/lib:/milvus/lib:/usr/lib
+        {{- end }}
+        ports:
+          - name: metrics
+            containerPort: 9091
+            protocol: TCP
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          tcpSocket:
+            port: metrics
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: metrics
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.cdc.resources | nindent 10 }}
+        volumeMounts:
+        {{- if .Values.customConfigMap }}
+        - name: milvus-config
+          mountPath: /milvus/configs/user.yaml
+          subPath: milvus.yaml
+          readOnly: true
+        {{- else }}
+        - name: milvus-config
+          mountPath: /milvus/configs/default.yaml
+          subPath: default.yaml
+          readOnly: true
+        - name: milvus-config
+          mountPath: /milvus/configs/user.yaml
+          subPath: user.yaml
+          readOnly: true
+        {{- end }}
+        {{- if .Values.log.persistence.enabled }}
+        - name: milvus-logs-disk
+          mountPath: {{ .Values.log.persistence.mountPath | quote }}
+          subPath: {{ .Values.log.persistence.persistentVolumeClaim.subPath | default "" }}
+        {{- end }}
+        - mountPath: /milvus/tools
+          name: tools
+        {{- if .Values.volumeMounts }}
+          {{- toYaml .Values.volumeMounts | nindent 8 }}
+        {{- end}}
+
+    {{- if and (.Values.nodeSelector) (not .Values.cdc.nodeSelector) }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.cdc.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.cdc.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.affinity) (not .Values.cdc.affinity) }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.cdc.affinity }}
+      affinity:
+{{ toYaml .Values.cdc.affinity | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.tolerations) (not .Values.cdc.tolerations) }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.cdc.tolerations }}
+      tolerations:
+{{ toYaml .Values.cdc.tolerations | indent 8 }}
+    {{- end }}
+
+    {{- if and (.Values.topologySpreadConstraints) (not .Values.cdc.topologySpreadConstraints) }}
+      topologySpreadConstraints:
+{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+    {{- end }}
+    {{- if .Values.cdc.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.cdc.topologySpreadConstraints | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.securityContext) (not .Values.cdc.securityContext) }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+    {{- end }}
+    {{- if .Values.cdc.securityContext }}
+      securityContext:
+{{ toYaml .Values.cdc.securityContext | indent 8 }}
+    {{- end }}
+
+      volumes:
+      - name: milvus-config
+        configMap:
+          {{- if .Values.customConfigMap }}
+          name: {{ .Values.customConfigMap }}
+          {{- else }}
+          name: {{ template "milvus.fullname" . }}
+          {{- end }}
+      {{- if .Values.log.persistence.enabled }}
+      - name: milvus-logs-disk
+        persistentVolumeClaim:
+          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- end }}
+      - name: tools
+        emptyDir: {}
+      {{- if .Values.volumes }}
+        {{- toYaml .Values.volumes | nindent 6 }}
+      {{- end}}
+{{- end }}

--- a/charts/milvus/templates/cdc-svc.yaml
+++ b/charts/milvus/templates/cdc-svc.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.metrics.enabled }}
+{{- if .Values.cdc.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "milvus.cdc.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "milvus.labels" . | indent 4 }}
+    component: "cdc"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 9091
+      targetPort: metrics
+  selector:
+{{ include "milvus.matchLabels" . | indent 4 }}
+    component: "cdc"
+{{- end }}
+{{- end }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -574,6 +574,24 @@ streamingNode:
     enabled: false  # Enable live profiling
   strategy: {}
 
+cdc:
+  enabled: false
+  replicas: 1   # Currently, CDC only supports one replica
+  resources: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  securityContext: {}
+  containerSecurityContext: {}
+  topologySpreadConstraints: []  # Component specific topologySpreadConstraints
+  extraEnv: []
+  heaptrack:
+    enabled: false
+  profiling:
+    enabled: false  # Enable live profiling
+  strategy: {}
+  annotations: {}
+
 attu:
   enabled: false
   name: attu


### PR DESCRIPTION
## What this PR does / why we need it:
This pull request introduces support for deploying the Milvus CDC (Change Data Capture) component via Helm charts, starting with Milvus v2.6.6+. It adds new configuration options, templates, and documentation to enable and customize the CDC deployment alongside existing Milvus components.

**Milvus CDC feature addition:**

* Added a new section to `README.md` describing CDC configuration parameters, their defaults, and deployment notes, including a warning that only one replica is currently supported.
* Introduced a new CDC configuration block in `values.yaml`, allowing users to enable CDC and customize resources, node selection, affinity, tolerations, security context, environment variables, heaptrack, profiling, deployment strategy, and annotations.

**CDC deployment and service templates:**

* Added `cdc-deployment.yaml` template to define the CDC deployment, supporting all new configuration options and integrating with existing Milvus Helm chart values.
* Added `cdc-svc.yaml` template to expose CDC metrics via a Kubernetes service when both metrics and CDC are enabled.
* Created a new Helm template helper `milvus.cdc.fullname` in `_helpers.tpl` for consistent CDC resource naming, following Kubernetes DNS naming conventions.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart