### PR TITLE
bump etcd

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: milvus
-appVersion: "2.6.6"
+appVersion: "2.6.7"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 5.0.9
+version: 5.1.0
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -335,7 +335,7 @@ The following table lists the configurable parameters of the Milvus Service and 
 | `route.annotations`                       | Route annotations                            | `{}`                                                   |
 | `route.labels`                           | Route labels                                 | `{}`                                                   |
 | `image.all.repository`                    | Image repository                              | `milvusdb/milvus`                                       |
-| `image.all.tag`                           | Image tag                                     | `v2.6.6`                           |
+| `image.all.tag`                           | Image tag                                     | `v2.6.7`                           |
 | `image.all.pullPolicy`                    | Image pull policy                             | `IfNotPresent`                                          |
 | `image.all.pullSecrets`                   | Image pull secrets                            | `{}`                                                    |
 | `image.tools.repository`                  | Config image repository                       | `milvusdb/milvus-config-tool`                                       |

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -11,7 +11,7 @@ cluster:
 image:
   all:
     repository: milvusdb/milvus
-    tag: v2.6.6
+    tag: v2.6.7
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -715,7 +715,7 @@ etcd:
     create: false
   image:
     repository: "milvusdb/etcd"
-    tag: "3.5.23-r2"
+    tag: "3.5.25-r1"
     pullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
## What this PR does / why we need it:
- Bump etcd version to 3.5.25 to fix CVE.
- Bump milvus version to 2.6.7.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] PR only contains changes for one chart
