### PR TITLE
[milvus] Add minio repository configuration and remove quotes from etcd repository

### DIFF
--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -651,6 +651,7 @@ minio:
   name: minio
   mode: distributed
   image:
+    repository: minio/minio
     tag: "RELEASE.2024-12-18T13-15-44Z"
     pullPolicy: IfNotPresent
   accessKey: minioadmin
@@ -714,7 +715,7 @@ etcd:
   pdb:
     create: false
   image:
-    repository: "milvusdb/etcd"
+    repository: milvusdb/etcd
     tag: "3.5.25-r1"
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fixes two image repository configuration issues:

1. **Adds missing `repository` field for minio image**: The minio image configuration was missing the `repository` field, which forces users to manually add `repository: minio/minio` when using private image registries. This change ensures consistency with other image configurations in the chart. (fix #274 )

2. **Removes quotes from etcd repository value**: The etcd repository value was wrapped in double quotes (`"milvusdb/etcd"`), which was the only repository value in the entire codebase using quotes. Removing the quotes makes it easier for scripts to customize the repository for private registry usage and maintains consistency across all repository configurations.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
