### PR TITLE
enhance: support replica resource group isolation in cluster mode

### DIFF
--- a/charts/milvus/templates/config.tpl
+++ b/charts/milvus/templates/config.tpl
@@ -200,6 +200,10 @@ queryCoord:
   port: {{ .Values.queryCoordinator.service.port }}
 
   enableActiveStandby: {{ template "milvus.querycoord.activeStandby" . }}  # Enable querycoord active-standby
+{{- if and .Values.cluster.enabled .Values.replicaResourceGroups }}
+  clusterLevelLoadReplicaNumber: {{ len .Values.replicaResourceGroups }}
+  clusterLevelLoadResourceGroups: {{ join "," .Values.replicaResourceGroups }}
+{{- end }}
 
 queryNode:
   port: 21123
@@ -271,5 +275,12 @@ woodpecker:
     rootPath: /woodpecker/data
 {{- else }}
     rootPath: /var/lib/milvus/wp
+{{- end }}
+
+{{- if and .Values.cluster.enabled .Values.replicaResourceGroups }}
+streaming:
+  primaryResourceGroup: {{ index .Values.replicaResourceGroups 0 }}
+  strictResourceGroupIsolation:
+    enabled: true
 {{- end }}
 {{- end }}

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -1,12 +1,16 @@
-{{- if and .Values.queryNode.enabled .Values.cluster.enabled }}
+{{/* Querynode deployment template. Accepts merged context with optional .rg for resource group. */}}
+{{- define "milvus.querynode.deployment" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "milvus.querynode.fullname" . }}
+  name: {{ template "milvus.querynode.fullname" . }}{{- if .rg }}-{{ .rg }}{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "querynode"
+{{- if .rg }}
+    milvus.io/resource-group: {{ .rg | quote }}
+{{- end }}
 {{ include "milvus.ud.labels" . | indent 4 }}
   annotations:
 {{ include "milvus.ud.annotations" . | indent 4 }}
@@ -23,16 +27,22 @@ spec:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}
       component: "querynode"
+{{- if .rg }}
+      milvus.io/resource-group: {{ .rg | quote }}
+{{- end }}
   template:
     metadata:
       labels:
 {{ include "milvus.matchLabels" . | indent 8 }}
         component: "querynode"
+{{- if .rg }}
+        milvus.io/resource-group: {{ .rg | quote }}
+{{- end }}
 {{ include "milvus.ud.labels" . | indent 8 }}
       annotations:
       {{- if .Values.queryNode.profiling.enabled }}
         pyroscope.io/scrape: "true"
-        pyroscope.io/application-name: {{ template "milvus.querynode.fullname" . }}
+        pyroscope.io/application-name: {{ template "milvus.querynode.fullname" . }}{{- if .rg }}-{{ .rg }}{{- end }}
         pyroscope.io/port: "9091"
       {{- end }}
       {{- if .Values.queryNode.annotations }}
@@ -100,6 +110,10 @@ spec:
             resourceFieldRef:
               divisor: 1Gi
               resource: limits.ephemeral-storage
+        {{- end }}
+        {{- if .rg }}
+        - name: MILVUS_SERVER_LABEL_RESOURCE_GROUP
+          value: {{ .rg | quote }}
         {{- end }}
         {{- if .Values.queryNode.extraEnv }}
           {{- toYaml .Values.queryNode.extraEnv | nindent 8 }}
@@ -229,4 +243,15 @@ spec:
       {{- if .Values.volumes }}
         {{- toYaml .Values.volumes | nindent 6 }}
       {{- end}}
+{{- end -}}
+
+{{- if and .Values.queryNode.enabled .Values.cluster.enabled }}
+{{- if .Values.replicaResourceGroups }}
+{{- range $rg := .Values.replicaResourceGroups }}
+---
+{{ include "milvus.querynode.deployment" (merge (dict "rg" $rg) $) }}
+{{- end }}
+{{- else }}
+{{ include "milvus.querynode.deployment" (merge (dict "rg" "") .) }}
+{{- end }}
 {{- end }}

--- a/charts/milvus/templates/streamingnode-deployment.yaml
+++ b/charts/milvus/templates/streamingnode-deployment.yaml
@@ -1,12 +1,16 @@
-{{- if and .Values.streaming .Values.streaming.enabled .Values.cluster.enabled }}
+{{/* Streamingnode deployment template. Accepts merged context with optional .rg for resource group. */}}
+{{- define "milvus.streamingnode.deployment" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "milvus.streamingnode.fullname" . }}
+  name: {{ template "milvus.streamingnode.fullname" . }}{{- if .rg }}-{{ .rg }}{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "streamingnode"
+{{- if .rg }}
+    milvus.io/resource-group: {{ .rg | quote }}
+{{- end }}
 
 {{ include "milvus.ud.labels" . | indent 4 }}
   annotations:
@@ -24,16 +28,22 @@ spec:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}
       component: "streamingnode"
+{{- if .rg }}
+      milvus.io/resource-group: {{ .rg | quote }}
+{{- end }}
   template:
     metadata:
       labels:
 {{ include "milvus.matchLabels" . | indent 8 }}
         component: "streamingnode"
+{{- if .rg }}
+        milvus.io/resource-group: {{ .rg | quote }}
+{{- end }}
 {{ include "milvus.ud.labels" . | indent 8 }}
       annotations:
       {{- if .Values.streamingNode.profiling.enabled }}
         pyroscope.io/scrape: "true"
-        pyroscope.io/application-name: {{ template "milvus.streamingnode.fullname" . }}
+        pyroscope.io/application-name: {{ template "milvus.streamingnode.fullname" . }}{{- if .rg }}-{{ .rg }}{{- end }}
         pyroscope.io/port: "9091"
       {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
@@ -88,6 +98,10 @@ spec:
         {{- if .Values.streamingNode.heaptrack.enabled }}
         - name: LD_LIBRARY_PATH
           value: /milvus/tools/heaptrack/lib:/milvus/lib:/usr/lib
+        {{- end }}
+        {{- if .rg }}
+        - name: MILVUS_SERVER_LABEL_RESOURCE_GROUP
+          value: {{ .rg | quote }}
         {{- end }}
         {{- if .Values.streamingNode.extraEnv }}
           {{- toYaml .Values.streamingNode.extraEnv | nindent 8 }}
@@ -215,4 +229,15 @@ spec:
       {{- if .Values.volumes }}
         {{- toYaml .Values.volumes | nindent 6 }}
       {{- end}}
+{{- end -}}
+
+{{- if and .Values.streaming .Values.streaming.enabled .Values.cluster.enabled }}
+{{- if .Values.replicaResourceGroups }}
+{{- range $rg := .Values.replicaResourceGroups }}
+---
+{{ include "milvus.streamingnode.deployment" (merge (dict "rg" $rg) $) }}
+{{- end }}
+{{- else }}
+{{ include "milvus.streamingnode.deployment" (merge (dict "rg" "") .) }}
+{{- end }}
 {{- end }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -8,6 +8,12 @@ fullnameOverride: ""
 cluster:
   enabled: true
 
+## Resource group isolation for multi-replica mode (cluster mode only).
+## List of resource group names (e.g., ["rg1", "rg2"]).
+## When set, creates per-RG querynode and streamingnode deployments,
+## and auto-configures cluster-level multi-replica settings.
+replicaResourceGroups: []
+
 image:
   all:
     repository: milvusdb/milvus


### PR DESCRIPTION
Add replicaResourceGroups parameter (comma-separated RG names) that creates per-RG querynode and streamingnode deployments with proper labels and env vars, and auto-configures cluster-level multi-replica settings in milvus config.
