### PR TITLE
[Minio] Ingress Version Upgrade and Support for multiple Ports

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.6.14"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 5.0.17
+version: 5.0.18
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/requirements.yaml
+++ b/charts/milvus/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
   tags:
     - etcd
 - name: minio
-  version: 8.0.17
+  version: 8.0.20
   repository: https://zilliztech.github.io/milvus-helm
   condition: minio.enabled
   tags:

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: High Performance, Kubernetes Native Object Storage
 name: minio
-version: 8.0.19
+version: 8.0.20
 appVersion: master
 keywords:
 - storage

--- a/charts/minio/templates/_helpers.tpl
+++ b/charts/minio/templates/_helpers.tpl
@@ -81,8 +81,10 @@ Return the appropriate apiVersion for ingress.
 {{- define "minio.ingress.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
-{{- else -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/minio/templates/service.yaml
+++ b/charts/minio/templates/service.yaml
@@ -28,15 +28,13 @@ spec:
 {{- else }}
   type: {{ .Values.service.type }}
 {{- end }}
-  ports:
-    - name: {{ $scheme }}
-      port: {{ .Values.service.port }}
-      protocol: TCP
-{{- if (and (eq .Values.service.type "NodePort") ( .Values.service.nodePort)) }}
-      nodePort: {{ .Values.service.nodePort }}
-{{- else }}
-      targetPort: 9000
-{{- end}}
+# loop to add all ports from .Values.service.ports
+{{- range .Values.service.ports }}
+  - name: {{ .name }}
+    port: {{ .port }}
+    protocol: TCP
+    targetPort: {{ .targetPort }}
+{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{- range $i , $ip := .Values.service.externalIPs }}

--- a/charts/minio/templates/service.yaml
+++ b/charts/minio/templates/service.yaml
@@ -34,6 +34,9 @@ spec:
     port: {{ .port }}
     protocol: TCP
     targetPort: {{ .targetPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .nodePort))) }}
+    nodePort: {{ .nodePort }}
+    {{- end }}
 {{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -160,10 +160,11 @@ service:
     - name: http
       port: 9000
       targetPort: 9000
+      nodePort: 32000
     - name: console
       port: 9001
       targetPort: 9001
-  nodePort: 32000
+      nodePort: 32001
 
   ## List of IP addresses at which the Prometheus server service is available
   ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -161,10 +161,11 @@ service:
       port: 9000
       targetPort: 9000
       nodePort: 32000
-    - name: console
-      port: 9001
-      targetPort: 9001
-      nodePort: 32001
+  # optional console port
+    # - name: console
+    #   port: 9001
+    #   targetPort: 9001
+    #   nodePort: 32001
 
   ## List of IP addresses at which the Prometheus server service is available
   ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -156,7 +156,13 @@ persistence:
 service:
   type: ClusterIP
   clusterIP: ~
-  port: 9000
+  ports:
+    - name: http
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001
   nodePort: 32000
 
   ## List of IP addresses at which the Prometheus server service is available


### PR DESCRIPTION
## What this PR does / why we need it:
- Solves Issues #285 and #286 
- adding support for newer apiversion for Ingress
- adding support for multiple ports in minio service.
- bumping chart versions 

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
