### PR TITLE
release tag 2.6.16

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: milvus
-appVersion: "2.6.15"
+appVersion: "2.6.16"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 5.0.19
+version: 5.0.20
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -335,7 +335,7 @@ The following table lists the configurable parameters of the Milvus Service and 
 | `route.annotations`                       | Route annotations                            | `{}`                                                   |
 | `route.labels`                           | Route labels                                 | `{}`                                                   |
 | `image.all.repository`                    | Image repository                              | `milvusdb/milvus`                                       |
-| `image.all.tag`                           | Image tag                                     | `v2.6.15`                           |
+| `image.all.tag`                           | Image tag                                     | `v2.6.16`                           |
 | `image.all.pullPolicy`                    | Image pull policy                             | `IfNotPresent`                                          |
 | `image.all.pullSecrets`                   | Image pull secrets                            | `{}`                                                    |
 | `image.tools.repository`                  | Config image repository                       | `milvusdb/milvus-config-tool`                                       |

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -17,7 +17,7 @@ replicaResourceGroups: []
 image:
   all:
     repository: milvusdb/milvus
-    tag: v2.6.15
+    tag: v2.6.16
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Summary: bump Milvus Helm chart to v2.6.16; update chart version to 5.0.20; update image.all.tag defaults. Verification: DockerHub tags v2.6.16, v2.6.16-debug, v2.6.16-amd64, v2.6.16-amd64-debug, v2.6.16-arm64, v2.6.16-arm64-debug returned 200; git diff --check passed; no stale 2.6.15/5.0.19 in updated chart files; helm lint charts/milvus passed.