### PR TITLE
release tag 2.6.18

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: milvus
-appVersion: "2.6.17"
+appVersion: "2.6.18"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 5.0.21
+version: 5.0.22
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -335,7 +335,7 @@ The following table lists the configurable parameters of the Milvus Service and 
 | `route.annotations`                       | Route annotations                            | `{}`                                                   |
 | `route.labels`                           | Route labels                                 | `{}`                                                   |
 | `image.all.repository`                    | Image repository                              | `milvusdb/milvus`                                       |
-| `image.all.tag`                           | Image tag                                     | `v2.6.17`                           |
+| `image.all.tag`                           | Image tag                                     | `v2.6.18`                           |
 | `image.all.pullPolicy`                    | Image pull policy                             | `IfNotPresent`                                          |
 | `image.all.pullSecrets`                   | Image pull secrets                            | `{}`                                                    |
 | `image.tools.repository`                  | Config image repository                       | `milvusdb/milvus-config-tool`                                       |

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -17,7 +17,7 @@ replicaResourceGroups: []
 image:
   all:
     repository: milvusdb/milvus
-    tag: v2.6.17
+    tag: v2.6.18
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Release Milvus Helm chart for v2.6.18. Evidence: DockerHub v2.6.18, v2.6.18-debug, v2.6.18-gpu, and v2.6.18-gpu-debug tags were verified as multi-arch, release-milvus-image #44 succeeded, and release-milvus-scan-image #48 succeeded. Local validation: git diff --check, targeted version grep, helm lint charts/milvus.