### PR TITLE
release tag 2.6.19

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: milvus
-appVersion: "2.6.18"
+appVersion: "2.6.19"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 5.0.22
+version: 5.0.23
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -335,7 +335,7 @@ The following table lists the configurable parameters of the Milvus Service and 
 | `route.annotations`                       | Route annotations                            | `{}`                                                   |
 | `route.labels`                           | Route labels                                 | `{}`                                                   |
 | `image.all.repository`                    | Image repository                              | `milvusdb/milvus`                                       |
-| `image.all.tag`                           | Image tag                                     | `v2.6.18`                           |
+| `image.all.tag`                           | Image tag                                     | `v2.6.19`                           |
 | `image.all.pullPolicy`                    | Image pull policy                             | `IfNotPresent`                                          |
 | `image.all.pullSecrets`                   | Image pull secrets                            | `{}`                                                    |
 | `image.tools.repository`                  | Config image repository                       | `milvusdb/milvus-config-tool`                                       |

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -17,7 +17,7 @@ replicaResourceGroups: []
 image:
   all:
     repository: milvusdb/milvus
-    tag: v2.6.18
+    tag: v2.6.19
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Updates the Milvus Helm chart for v2.6.19.

Summary:
- Set chart appVersion to 2.6.19.
- Bump chart version to 5.0.23.
- Set default milvusdb/milvus image tag to v2.6.19 and refresh README defaults.

Validation:
- DockerHub docker.io/milvusdb/milvus:v2.6.19 inspected for linux/amd64 and linux/arm64.
- git diff --check upstream/master..HEAD.
- helm lint charts/milvus.