### PR TITLE
[milvus] Support component deployment groups

### DIFF
--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -439,6 +439,7 @@ The following table lists the configurable parameters of the Milvus Proxy compon
 |-------------------------------------------|---------------------------------------------------------|---------------|
 | `proxy.enabled`                           | Enable or disable Milvus Proxy Deployment               | `true`        |
 | `proxy.replicas`                          | Desired number of Milvus Proxy pods                     | `1`           |
+| `proxy.groups`                            | Optional deployment groups for rendering multiple Proxy Deployments | `[]` |
 | `proxy.resources`                         | Resource requests/limits for the Milvus Proxy pods      | `{}`          |
 | `proxy.nodeSelector`                      | Node labels for Milvus Proxy pods assignment            | `{}`          |
 | `proxy.affinity`                          | Affinity settings for Milvus Proxy pods assignment      | `{}`          |
@@ -468,6 +469,7 @@ The following table lists the configurable parameters of the Milvus Query Node c
 |-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
 | `queryNode.enabled`                       | Enable or disable Milvus Query Node component | `true`                                                  |
 | `queryNode.replicas`                      | Desired number of Milvus Query Node pods | `1`                                                          |
+| `queryNode.groups`                        | Optional deployment groups for rendering multiple Query Node Deployments | `[]` |
 | `queryNode.resources`                     | Resource requests/limits for the Milvus Query Node pods | `{}`                                          |
 | `queryNode.nodeSelector`                  | Node labels for Milvus Query Node pods assignment | `{}`                                                |
 | `queryNode.affinity`                      | Affinity settings for Milvus Query Node pods assignment | `{}`                                          |
@@ -496,6 +498,7 @@ The following table lists the configurable parameters of the Milvus Data Node co
 |-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
 | `dataNode.enabled`                        | Enable or disable Data Node component         | `true`                                                  |
 | `dataNode.replicas`                       | Desired number of Data Node pods               | `1`                                                    |
+| `dataNode.groups`                         | Optional deployment groups for rendering multiple Data Node Deployments | `[]` |
 | `dataNode.resources`                      | Resource requests/limits for the Milvus Data Node pods | `{}`                                           |
 | `dataNode.nodeSelector`                   | Node labels for Milvus Data Node pods assignment | `{}`                                                 |
 | `dataNode.affinity`                       | Affinity settings for Milvus Data Node pods assignment | `{}`                                           |
@@ -518,6 +521,7 @@ The following table lists the configurable parameters of the Milvus Mix Coordina
 |-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
 | `mixCoordinator.enabled`                 | Enable or disable Mix Coordinator component  | `true`                                                  |
 | `mixCoordinator.replicas`                | Desired number of Mix Coordinator pods       | `1`                                                     |
+| `mixCoordinator.labels`                  | Additional labels for the single Mix Coordinator Deployment and pods | `{}` |
 | `mixCoordinator.resources`               | Resource requests/limits for the Milvus Mix Coordinator pods | `{}`                                    |
 | `mixCoordinator.nodeSelector`            | Node labels for Milvus Mix Coordinator pods assignment | `{}`                                          |
 | `mixCoordinator.affinity`                | Affinity settings for Milvus Mix Coordinator pods assignment  | `{}`                                   |
@@ -544,6 +548,7 @@ The following table lists the configurable parameters of the Milvus Streaming No
 |-------------------------------------------|---------------------------------------------------------|---------------|
 | `streamingNode.enabled`                   | Enable or disable Streaming Node component             | `true`        |
 | `streamingNode.replicas`                  | Desired number of Streaming Node pods                  | `1`           |
+| `streamingNode.groups`                    | Optional deployment groups for rendering multiple Streaming Node Deployments | `[]` |
 | `streamingNode.resources`                 | Resource requests/limits for the Milvus Streaming Node pods | `{}`      |
 | `streamingNode.nodeSelector`              | Node labels for Milvus Streaming Node pods assignment  | `{}`          |
 | `streamingNode.affinity`                  | Affinity settings for Milvus Streaming Node pods assignment | `{}`      |
@@ -695,6 +700,7 @@ The following table lists the configurable parameters of the Woodpecker componen
 - [Node Selector Configuration Guide](../../docs/node-selector-configuration-guide.md)
 - [Affinity Configuration Guide](../../docs/affinity-configuration-guide.md)
 - [Tolerations Configuration Guide](../../docs/tolerations-configuration-guide.md)
+- [Deployment Groups and Resource Group Guide](../../docs/deployment-groups-resource-group-guide.md)
 
 #### Important Configuration Considerations
 

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -1,20 +1,38 @@
-{{- if and .Values.dataNode.enabled .Values.cluster.enabled }}
+{{/* Datanode deployment template. Accepts merged context with optional .group. */}}
+{{- define "milvus.datanode.deployment" -}}
+{{- $groupName := "" -}}
+{{- if .group }}
+{{- $groupName = required "dataNode.groups[].name is required" .group.name -}}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "milvus.datanode.fullname" . }}
+  name: {{ template "milvus.datanode.fullname" . }}{{- if $groupName }}-{{ $groupName }}{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "datanode"
+{{- with .group.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if $groupName }}
+    milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
 
 {{ include "milvus.ud.labels" . | indent 4 }}
   annotations:
 {{ include "milvus.ud.annotations" . | indent 4 }}
+{{- with .group.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 
 spec:
-  {{- if ge (int .Values.dataNode.replicas) 0 }}
-  replicas: {{ .Values.dataNode.replicas }}
+  {{- $replicas := .Values.dataNode.replicas -}}
+  {{- if and .group (hasKey .group "replicas") -}}
+  {{- $replicas = .group.replicas -}}
+  {{- end }}
+  {{- if ge (int $replicas) 0 }}
+  replicas: {{ $replicas }}
   {{- end }}
   {{- with .Values.dataNode.strategy }}
   strategy:
@@ -24,11 +42,20 @@ spec:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}
       component: "datanode"
+{{- if $groupName }}
+      milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
   template:
     metadata:
       labels:
 {{ include "milvus.matchLabels" . | indent 8 }}
         component: "datanode"
+{{- with .group.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if $groupName }}
+        milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
 {{ include "milvus.ud.labels" . | indent 8 }}
       annotations:
       {{- if .Values.dataNode.profiling.enabled }}
@@ -38,6 +65,9 @@ spec:
       {{- end }}
       {{- if .Values.dataNode.annotations }}
         {{- toYaml .Values.dataNode.annotations | nindent 8 }}
+      {{- end }}
+      {{- with .group.annotations }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
@@ -94,6 +124,9 @@ spec:
         {{- end }}
         {{- if .Values.dataNode.extraEnv }}
           {{- toYaml .Values.dataNode.extraEnv | nindent 8 }}
+        {{- end }}
+        {{- if .group.extraEnv }}
+          {{- toYaml .group.extraEnv | nindent 8 }}
         {{- end }}
         ports:
           - name: datanode
@@ -152,37 +185,53 @@ spec:
           {{- toYaml .Values.volumeMounts | nindent 8 }}
         {{- end}}
 
-    {{- if and (.Values.nodeSelector) (not .Values.dataNode.nodeSelector) }}
+    {{- $nodeSelector := .Values.dataNode.nodeSelector -}}
+    {{- if and .group .group.nodeSelector -}}
+    {{- $nodeSelector = .group.nodeSelector -}}
+    {{- end }}
+    {{- if and (.Values.nodeSelector) (not $nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.dataNode.nodeSelector }}
+    {{- if $nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.dataNode.nodeSelector | indent 8 }}
+{{ toYaml $nodeSelector | indent 8 }}
     {{- end }}
-    {{- if and (.Values.affinity) (not .Values.dataNode.affinity) }}
+    {{- $affinity := .Values.dataNode.affinity -}}
+    {{- if and .group .group.affinity -}}
+    {{- $affinity = .group.affinity -}}
+    {{- end }}
+    {{- if and (.Values.affinity) (not $affinity) }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
-    {{- if .Values.dataNode.affinity }}
+    {{- if $affinity }}
       affinity:
-{{ toYaml .Values.dataNode.affinity | indent 8 }}
+{{ toYaml $affinity | indent 8 }}
     {{- end }}
-    {{- if and (.Values.tolerations) (not .Values.dataNode.tolerations) }}
+    {{- $tolerations := .Values.dataNode.tolerations -}}
+    {{- if and .group .group.tolerations -}}
+    {{- $tolerations = .group.tolerations -}}
+    {{- end }}
+    {{- if and (.Values.tolerations) (not $tolerations) }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
-    {{- if .Values.dataNode.tolerations }}
+    {{- if $tolerations }}
       tolerations:
-{{ toYaml .Values.dataNode.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
     {{- end }}
-    {{- if and (.Values.topologySpreadConstraints) (not .Values.dataNode.topologySpreadConstraints) }}
+    {{- $topologySpreadConstraints := .Values.dataNode.topologySpreadConstraints -}}
+    {{- if and .group .group.topologySpreadConstraints -}}
+    {{- $topologySpreadConstraints = .group.topologySpreadConstraints -}}
+    {{- end }}
+    {{- if and (.Values.topologySpreadConstraints) (not $topologySpreadConstraints) }}
       topologySpreadConstraints:
 {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
     {{- end }}
-    {{- if .Values.dataNode.topologySpreadConstraints }}
+    {{- if $topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml .Values.dataNode.topologySpreadConstraints | indent 8 }}
+{{ toYaml $topologySpreadConstraints | indent 8 }}
     {{- end }}
     {{- if and (.Values.securityContext) (not .Values.dataNode.securityContext) }}
       securityContext:
@@ -210,4 +259,15 @@ spec:
       {{- if .Values.volumes }}
         {{- toYaml .Values.volumes | nindent 6 }}
       {{- end}}
+{{- end -}}
+
+{{- if and .Values.dataNode.enabled .Values.cluster.enabled }}
+{{- if .Values.dataNode.groups }}
+{{- range $group := .Values.dataNode.groups }}
+---
+{{ include "milvus.datanode.deployment" (merge (dict "group" $group) $) }}
+{{- end }}
+{{- else }}
+{{ include "milvus.datanode.deployment" (merge (dict "group" (dict)) .) }}
+{{- end }}
 {{- end }}

--- a/charts/milvus/templates/datanode-hpa.yaml
+++ b/charts/milvus/templates/datanode-hpa.yaml
@@ -1,16 +1,23 @@
-{{- if and .Values.dataNode.enabled .Values.dataNode.hpa.enabled }}
+{{- define "milvus.datanode.hpa" -}}
+{{- $groupName := "" -}}
+{{- if .group }}
+{{- $groupName = required "dataNode.groups[].name is required" .group.name -}}
+{{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "milvus.datanode.fullname" . }}-hpa
+  name: {{ template "milvus.datanode.fullname" . }}{{- if $groupName }}-{{ $groupName }}{{- end }}-hpa
   namespace: {{ .Release.Namespace }}
   labels:
     component: "datanode"
+{{- if $groupName }}
+    milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "milvus.datanode.fullname" . }}
+    name: {{ template "milvus.datanode.fullname" . }}{{- if $groupName }}-{{ $groupName }}{{- end }}
   minReplicas: {{ .Values.dataNode.hpa.minReplicas | default 1 }}
   maxReplicas: {{ .Values.dataNode.hpa.maxReplicas | default 10 }}
   metrics:
@@ -20,4 +27,15 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.dataNode.hpa.cpuUtilization | default 40 }}
+{{- end -}}
+
+{{- if and .Values.dataNode.enabled .Values.dataNode.hpa.enabled }}
+{{- if .Values.dataNode.groups }}
+{{- range $group := .Values.dataNode.groups }}
+---
+{{ include "milvus.datanode.hpa" (merge (dict "group" $group) $) }}
+{{- end }}
+{{- else }}
+{{ include "milvus.datanode.hpa" (merge (dict "group" (dict)) .) }}
+{{- end }}
 {{- end }}

--- a/charts/milvus/templates/mixcoord-deployment.yaml
+++ b/charts/milvus/templates/mixcoord-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "mixcoord"
+{{- with .Values.mixCoordinator.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{ include "milvus.ud.labels" . | indent 4 }}
   annotations:
 {{ include "milvus.ud.annotations" . | indent 4 }}
@@ -34,6 +37,9 @@ spec:
 {{ include "milvus.matchLabels" . | indent 8 }}
 {{ include "milvus.ud.labels" . | indent 8 }}
         component: "mixcoord"
+{{- with .Values.mixCoordinator.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       annotations:
       {{- if .Values.mixCoordinator.profiling.enabled }}
         pyroscope.io/scrape: "true"

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -1,20 +1,38 @@
-{{- if and .Values.proxy.enabled .Values.cluster.enabled }}
+{{/* Proxy deployment template. Accepts merged context with optional .group. */}}
+{{- define "milvus.proxy.deployment" -}}
+{{- $groupName := "" -}}
+{{- if .group }}
+{{- $groupName = required "proxy.groups[].name is required" .group.name -}}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "milvus.proxy.fullname" . }}
+  name: {{ template "milvus.proxy.fullname" . }}{{- if $groupName }}-{{ $groupName }}{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "proxy"
+{{- with .group.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if $groupName }}
+    milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
 
 {{ include "milvus.ud.labels" . | indent 4 }}
   annotations:
 {{ include "milvus.ud.annotations" . | indent 4 }}
+{{- with .group.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 
 spec:
-  {{- if ge (int .Values.proxy.replicas) 0 }}
-  replicas: {{ .Values.proxy.replicas }}
+  {{- $replicas := .Values.proxy.replicas -}}
+  {{- if and .group (hasKey .group "replicas") -}}
+  {{- $replicas = .group.replicas -}}
+  {{- end }}
+  {{- if ge (int $replicas) 0 }}
+  replicas: {{ $replicas }}
   {{- end }}
   {{- with .Values.proxy.strategy }}
   strategy:
@@ -24,11 +42,20 @@ spec:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}
       component: "proxy"
+{{- if $groupName }}
+      milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
   template:
     metadata:
       labels:
 {{ include "milvus.matchLabels" . | indent 8 }}
         component: "proxy"
+{{- with .group.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if $groupName }}
+        milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
 {{ include "milvus.ud.labels" . | indent 8 }}
       annotations:
       {{- if .Values.proxy.profiling.enabled }}
@@ -38,6 +65,9 @@ spec:
       {{- end }}
       {{- if .Values.proxy.annotations }}
         {{- toYaml .Values.proxy.annotations | nindent 8 }}
+      {{- end }}
+      {{- with .group.annotations }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
@@ -94,6 +124,9 @@ spec:
         {{- end }}
         {{- if .Values.proxy.extraEnv }}
           {{- toYaml .Values.proxy.extraEnv | nindent 8 }}
+        {{- end }}
+        {{- if .group.extraEnv }}
+          {{- toYaml .group.extraEnv | nindent 8 }}
         {{- end }}
         ports:
           - name: milvus
@@ -155,38 +188,54 @@ spec:
           {{- toYaml .Values.volumeMounts | nindent 8 }}
         {{- end}}
 
-    {{- if and (.Values.nodeSelector) (not .Values.proxy.nodeSelector) }}
+    {{- $nodeSelector := .Values.proxy.nodeSelector -}}
+    {{- if and .group .group.nodeSelector -}}
+    {{- $nodeSelector = .group.nodeSelector -}}
+    {{- end }}
+    {{- if and (.Values.nodeSelector) (not $nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.proxy.nodeSelector }}
+    {{- if $nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.proxy.nodeSelector | indent 8 }}
+{{ toYaml $nodeSelector | indent 8 }}
     {{- end }}
-    {{- if and (.Values.affinity) (not .Values.proxy.affinity) }}
+    {{- $affinity := .Values.proxy.affinity -}}
+    {{- if and .group .group.affinity -}}
+    {{- $affinity = .group.affinity -}}
+    {{- end }}
+    {{- if and (.Values.affinity) (not $affinity) }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
-    {{- if .Values.proxy.affinity }}
+    {{- if $affinity }}
       affinity:
-{{ toYaml .Values.proxy.affinity | indent 8 }}
+{{ toYaml $affinity | indent 8 }}
     {{- end }}
-    {{- if and (.Values.tolerations) (not .Values.proxy.tolerations) }}
+    {{- $tolerations := .Values.proxy.tolerations -}}
+    {{- if and .group .group.tolerations -}}
+    {{- $tolerations = .group.tolerations -}}
+    {{- end }}
+    {{- if and (.Values.tolerations) (not $tolerations) }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
-    {{- if .Values.proxy.tolerations }}
+    {{- if $tolerations }}
       tolerations:
-{{ toYaml .Values.proxy.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
     {{- end }}
 
-    {{- if and (.Values.topologySpreadConstraints) (not .Values.proxy.topologySpreadConstraints) }}
+    {{- $topologySpreadConstraints := .Values.proxy.topologySpreadConstraints -}}
+    {{- if and .group .group.topologySpreadConstraints -}}
+    {{- $topologySpreadConstraints = .group.topologySpreadConstraints -}}
+    {{- end }}
+    {{- if and (.Values.topologySpreadConstraints) (not $topologySpreadConstraints) }}
       topologySpreadConstraints:
 {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
     {{- end }}
-    {{- if .Values.proxy.topologySpreadConstraints }}
+    {{- if $topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml .Values.proxy.topologySpreadConstraints | indent 8 }}
+{{ toYaml $topologySpreadConstraints | indent 8 }}
     {{- end }}
     {{- if and (.Values.securityContext) (not .Values.proxy.securityContext) }}
       securityContext:
@@ -218,4 +267,15 @@ spec:
       {{- if .Values.volumes }}
         {{- toYaml .Values.volumes | nindent 6 }}
       {{- end}}
+{{- end -}}
+
+{{- if and .Values.proxy.enabled .Values.cluster.enabled }}
+{{- if .Values.proxy.groups }}
+{{- range $group := .Values.proxy.groups }}
+---
+{{ include "milvus.proxy.deployment" (merge (dict "group" $group) $) }}
+{{- end }}
+{{- else }}
+{{ include "milvus.proxy.deployment" (merge (dict "group" (dict)) .) }}
+{{- end }}
 {{- end }}

--- a/charts/milvus/templates/proxy-hpa.yaml
+++ b/charts/milvus/templates/proxy-hpa.yaml
@@ -1,16 +1,23 @@
-{{- if and .Values.proxy.enabled .Values.proxy.hpa.enabled }}
+{{- define "milvus.proxy.hpa" -}}
+{{- $groupName := "" -}}
+{{- if .group }}
+{{- $groupName = required "proxy.groups[].name is required" .group.name -}}
+{{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "milvus.proxy.fullname" . }}-hpa
+  name: {{ template "milvus.proxy.fullname" . }}{{- if $groupName }}-{{ $groupName }}{{- end }}-hpa
   namespace: {{ .Release.Namespace }}
   labels:
     component: "proxy"
+{{- if $groupName }}
+    milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "milvus.proxy.fullname" . }}
+    name: {{ template "milvus.proxy.fullname" . }}{{- if $groupName }}-{{ $groupName }}{{- end }}
   minReplicas: {{ .Values.proxy.hpa.minReplicas | default 1 }}
   maxReplicas: {{ .Values.proxy.hpa.maxReplicas | default 10 }}
   metrics:
@@ -20,4 +27,15 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.proxy.hpa.cpuUtilization | default 40 }}
+{{- end -}}
+
+{{- if and .Values.proxy.enabled .Values.proxy.hpa.enabled }}
+{{- if .Values.proxy.groups }}
+{{- range $group := .Values.proxy.groups }}
+---
+{{ include "milvus.proxy.hpa" (merge (dict "group" $group) $) }}
+{{- end }}
+{{- else }}
+{{ include "milvus.proxy.hpa" (merge (dict "group" (dict)) .) }}
+{{- end }}
 {{- end }}

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -1,23 +1,44 @@
 {{/* Querynode deployment template. Accepts merged context with optional .rg for resource group. */}}
 {{- define "milvus.querynode.deployment" -}}
+{{- $groupName := "" -}}
+{{- if .group }}
+{{- $groupName = required "queryNode.groups[].name is required" .group.name -}}
+{{- end }}
+{{- $nameSuffix := $groupName -}}
+{{- if and (not $nameSuffix) .rg -}}
+{{- $nameSuffix = .rg -}}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "milvus.querynode.fullname" . }}{{- if .rg }}-{{ .rg }}{{- end }}
+  name: {{ template "milvus.querynode.fullname" . }}{{- if $nameSuffix }}-{{ $nameSuffix }}{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "querynode"
+{{- with .group.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if $groupName }}
+    milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
 {{- if .rg }}
     milvus.io/resource-group: {{ .rg | quote }}
 {{- end }}
 {{ include "milvus.ud.labels" . | indent 4 }}
   annotations:
 {{ include "milvus.ud.annotations" . | indent 4 }}
+{{- with .group.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 
 spec:
-  {{- if ge (int .Values.queryNode.replicas) 0 }}
-  replicas: {{ .Values.queryNode.replicas }}
+  {{- $replicas := .Values.queryNode.replicas -}}
+  {{- if and .group (hasKey .group "replicas") -}}
+  {{- $replicas = .group.replicas -}}
+  {{- end }}
+  {{- if ge (int $replicas) 0 }}
+  replicas: {{ $replicas }}
   {{- end }}
   {{- with .Values.queryNode.strategy }}
   strategy:
@@ -27,6 +48,9 @@ spec:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}
       component: "querynode"
+{{- if $groupName }}
+      milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
 {{- if .rg }}
       milvus.io/resource-group: {{ .rg | quote }}
 {{- end }}
@@ -35,6 +59,12 @@ spec:
       labels:
 {{ include "milvus.matchLabels" . | indent 8 }}
         component: "querynode"
+{{- with .group.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if $groupName }}
+        milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
 {{- if .rg }}
         milvus.io/resource-group: {{ .rg | quote }}
 {{- end }}
@@ -42,11 +72,14 @@ spec:
       annotations:
       {{- if .Values.queryNode.profiling.enabled }}
         pyroscope.io/scrape: "true"
-        pyroscope.io/application-name: {{ template "milvus.querynode.fullname" . }}{{- if .rg }}-{{ .rg }}{{- end }}
+        pyroscope.io/application-name: {{ template "milvus.querynode.fullname" . }}{{- if $nameSuffix }}-{{ $nameSuffix }}{{- end }}
         pyroscope.io/port: "9091"
       {{- end }}
       {{- if .Values.queryNode.annotations }}
         {{- toYaml .Values.queryNode.annotations | nindent 8 }}
+      {{- end }}
+      {{- with .group.annotations }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
@@ -118,6 +151,9 @@ spec:
         {{- if .Values.queryNode.extraEnv }}
           {{- toYaml .Values.queryNode.extraEnv | nindent 8 }}
         {{- end }}
+        {{- if .group.extraEnv }}
+          {{- toYaml .group.extraEnv | nindent 8 }}
+        {{- end }}
         ports:
           - name: querynode
             containerPort: 21123
@@ -179,38 +215,54 @@ spec:
           {{- toYaml .Values.volumeMounts | nindent 8 }}
         {{- end}}
 
-    {{- if and (.Values.nodeSelector) (not .Values.queryNode.nodeSelector) }}
+    {{- $nodeSelector := .Values.queryNode.nodeSelector -}}
+    {{- if and .group .group.nodeSelector -}}
+    {{- $nodeSelector = .group.nodeSelector -}}
+    {{- end }}
+    {{- if and (.Values.nodeSelector) (not $nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.queryNode.nodeSelector }}
+    {{- if $nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.queryNode.nodeSelector | indent 8 }}
+{{ toYaml $nodeSelector | indent 8 }}
     {{- end }}
-    {{- if and (.Values.affinity) (not .Values.queryNode.affinity) }}
+    {{- $affinity := .Values.queryNode.affinity -}}
+    {{- if and .group .group.affinity -}}
+    {{- $affinity = .group.affinity -}}
+    {{- end }}
+    {{- if and (.Values.affinity) (not $affinity) }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
-    {{- if .Values.queryNode.affinity }}
+    {{- if $affinity }}
       affinity:
-{{ toYaml .Values.queryNode.affinity | indent 8 }}
+{{ toYaml $affinity | indent 8 }}
     {{- end }}
-    {{- if and (.Values.tolerations) (not .Values.queryNode.tolerations) }}
+    {{- $tolerations := .Values.queryNode.tolerations -}}
+    {{- if and .group .group.tolerations -}}
+    {{- $tolerations = .group.tolerations -}}
+    {{- end }}
+    {{- if and (.Values.tolerations) (not $tolerations) }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
-    {{- if .Values.queryNode.tolerations }}
+    {{- if $tolerations }}
       tolerations:
-{{ toYaml .Values.queryNode.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
     {{- end }}
 
-    {{- if and (.Values.topologySpreadConstraints) (not .Values.queryNode.topologySpreadConstraints) }}
+    {{- $topologySpreadConstraints := .Values.queryNode.topologySpreadConstraints -}}
+    {{- if and .group .group.topologySpreadConstraints -}}
+    {{- $topologySpreadConstraints = .group.topologySpreadConstraints -}}
+    {{- end }}
+    {{- if and (.Values.topologySpreadConstraints) (not $topologySpreadConstraints) }}
       topologySpreadConstraints:
 {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
     {{- end }}
-    {{- if .Values.queryNode.topologySpreadConstraints }}
+    {{- if $topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml .Values.queryNode.topologySpreadConstraints | indent 8 }}
+{{ toYaml $topologySpreadConstraints | indent 8 }}
     {{- end }}
     {{- if and (.Values.securityContext) (not .Values.queryNode.securityContext) }}
       securityContext:
@@ -246,12 +298,17 @@ spec:
 {{- end -}}
 
 {{- if and .Values.queryNode.enabled .Values.cluster.enabled }}
-{{- if .Values.replicaResourceGroups }}
+{{- if .Values.queryNode.groups }}
+{{- range $group := .Values.queryNode.groups }}
+---
+{{ include "milvus.querynode.deployment" (merge (dict "group" $group "rg" "") $) }}
+{{- end }}
+{{- else if .Values.replicaResourceGroups }}
 {{- range $rg := .Values.replicaResourceGroups }}
 ---
-{{ include "milvus.querynode.deployment" (merge (dict "rg" $rg) $) }}
+{{ include "milvus.querynode.deployment" (merge (dict "group" (dict) "rg" $rg) $) }}
 {{- end }}
 {{- else }}
-{{ include "milvus.querynode.deployment" (merge (dict "rg" "") .) }}
+{{ include "milvus.querynode.deployment" (merge (dict "group" (dict) "rg" "") .) }}
 {{- end }}
 {{- end }}

--- a/charts/milvus/templates/querynode-hpa.yaml
+++ b/charts/milvus/templates/querynode-hpa.yaml
@@ -1,16 +1,30 @@
-{{- if and .Values.queryNode.enabled .Values.queryNode.hpa.enabled }}
+{{- define "milvus.querynode.hpa" -}}
+{{- $groupName := "" -}}
+{{- if .group }}
+{{- $groupName = required "queryNode.groups[].name is required" .group.name -}}
+{{- end }}
+{{- $nameSuffix := $groupName -}}
+{{- if and (not $nameSuffix) .rg -}}
+{{- $nameSuffix = .rg -}}
+{{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "milvus.querynode.fullname" . }}-hpa
+  name: {{ template "milvus.querynode.fullname" . }}{{- if $nameSuffix }}-{{ $nameSuffix }}{{- end }}-hpa
   namespace: {{ .Release.Namespace }}
   labels:
     component: "querynode"
+{{- if $groupName }}
+    milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
+{{- if .rg }}
+    milvus.io/resource-group: {{ .rg | quote }}
+{{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "milvus.querynode.fullname" . }}
+    name: {{ template "milvus.querynode.fullname" . }}{{- if $nameSuffix }}-{{ $nameSuffix }}{{- end }}
   minReplicas: {{ .Values.queryNode.hpa.minReplicas | default 1 }}
   maxReplicas: {{ .Values.queryNode.hpa.maxReplicas | default 10 }}
   metrics:
@@ -26,4 +40,20 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.queryNode.hpa.memoryUtilization | default 40 }}
+{{- end -}}
+
+{{- if and .Values.queryNode.enabled .Values.queryNode.hpa.enabled }}
+{{- if .Values.queryNode.groups }}
+{{- range $group := .Values.queryNode.groups }}
+---
+{{ include "milvus.querynode.hpa" (merge (dict "group" $group "rg" "") $) }}
+{{- end }}
+{{- else if .Values.replicaResourceGroups }}
+{{- range $rg := .Values.replicaResourceGroups }}
+---
+{{ include "milvus.querynode.hpa" (merge (dict "group" (dict) "rg" $rg) $) }}
+{{- end }}
+{{- else }}
+{{ include "milvus.querynode.hpa" (merge (dict "group" (dict) "rg" "") .) }}
+{{- end }}
 {{- end }}

--- a/charts/milvus/templates/streamingnode-deployment.yaml
+++ b/charts/milvus/templates/streamingnode-deployment.yaml
@@ -1,13 +1,27 @@
 {{/* Streamingnode deployment template. Accepts merged context with optional .rg for resource group. */}}
 {{- define "milvus.streamingnode.deployment" -}}
+{{- $groupName := "" -}}
+{{- if .group }}
+{{- $groupName = required "streamingNode.groups[].name is required" .group.name -}}
+{{- end }}
+{{- $nameSuffix := $groupName -}}
+{{- if and (not $nameSuffix) .rg -}}
+{{- $nameSuffix = .rg -}}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "milvus.streamingnode.fullname" . }}{{- if .rg }}-{{ .rg }}{{- end }}
+  name: {{ template "milvus.streamingnode.fullname" . }}{{- if $nameSuffix }}-{{ $nameSuffix }}{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "streamingnode"
+{{- with .group.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if $groupName }}
+    milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
 {{- if .rg }}
     milvus.io/resource-group: {{ .rg | quote }}
 {{- end }}
@@ -15,10 +29,17 @@ metadata:
 {{ include "milvus.ud.labels" . | indent 4 }}
   annotations:
 {{ include "milvus.ud.annotations" . | indent 4 }}
+{{- with .group.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 
 spec:
-  {{- if ge (int .Values.streamingNode.replicas) 0 }}
-  replicas: {{ .Values.streamingNode.replicas }}
+  {{- $replicas := .Values.streamingNode.replicas -}}
+  {{- if and .group (hasKey .group "replicas") -}}
+  {{- $replicas = .group.replicas -}}
+  {{- end }}
+  {{- if ge (int $replicas) 0 }}
+  replicas: {{ $replicas }}
   {{- end }}
   {{- with .Values.streamingNode.strategy }}
   strategy:
@@ -28,6 +49,9 @@ spec:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}
       component: "streamingnode"
+{{- if $groupName }}
+      milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
 {{- if .rg }}
       milvus.io/resource-group: {{ .rg | quote }}
 {{- end }}
@@ -36,6 +60,12 @@ spec:
       labels:
 {{ include "milvus.matchLabels" . | indent 8 }}
         component: "streamingnode"
+{{- with .group.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if $groupName }}
+        milvus.io/deployment-group: {{ $groupName | quote }}
+{{- end }}
 {{- if .rg }}
         milvus.io/resource-group: {{ .rg | quote }}
 {{- end }}
@@ -43,8 +73,11 @@ spec:
       annotations:
       {{- if .Values.streamingNode.profiling.enabled }}
         pyroscope.io/scrape: "true"
-        pyroscope.io/application-name: {{ template "milvus.streamingnode.fullname" . }}{{- if .rg }}-{{ .rg }}{{- end }}
+        pyroscope.io/application-name: {{ template "milvus.streamingnode.fullname" . }}{{- if $nameSuffix }}-{{ $nameSuffix }}{{- end }}
         pyroscope.io/port: "9091"
+      {{- end }}
+      {{- with .group.annotations }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
@@ -105,6 +138,9 @@ spec:
         {{- end }}
         {{- if .Values.streamingNode.extraEnv }}
           {{- toYaml .Values.streamingNode.extraEnv | nindent 8 }}
+        {{- end }}
+        {{- if .group.extraEnv }}
+          {{- toYaml .group.extraEnv | nindent 8 }}
         {{- end }}
         ports:
           - name: streamingnode
@@ -167,37 +203,53 @@ spec:
           {{- toYaml .Values.volumeMounts | nindent 8 }}
         {{- end}}
 
-    {{- if and (.Values.nodeSelector) (not .Values.streamingNode.nodeSelector) }}
+    {{- $nodeSelector := .Values.streamingNode.nodeSelector -}}
+    {{- if and .group .group.nodeSelector -}}
+    {{- $nodeSelector = .group.nodeSelector -}}
+    {{- end }}
+    {{- if and (.Values.nodeSelector) (not $nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.streamingNode.nodeSelector }}
+    {{- if $nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.streamingNode.nodeSelector | indent 8 }}
+{{ toYaml $nodeSelector | indent 8 }}
     {{- end }}
-    {{- if and (.Values.affinity) (not .Values.streamingNode.affinity) }}
+    {{- $affinity := .Values.streamingNode.affinity -}}
+    {{- if and .group .group.affinity -}}
+    {{- $affinity = .group.affinity -}}
+    {{- end }}
+    {{- if and (.Values.affinity) (not $affinity) }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
-    {{- if .Values.streamingNode.affinity }}
+    {{- if $affinity }}
       affinity:
-{{ toYaml .Values.streamingNode.affinity | indent 8 }}
+{{ toYaml $affinity | indent 8 }}
     {{- end }}
-    {{- if and (.Values.tolerations) (not .Values.streamingNode.tolerations) }}
+    {{- $tolerations := .Values.streamingNode.tolerations -}}
+    {{- if and .group .group.tolerations -}}
+    {{- $tolerations = .group.tolerations -}}
+    {{- end }}
+    {{- if and (.Values.tolerations) (not $tolerations) }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
-    {{- if .Values.streamingNode.tolerations }}
+    {{- if $tolerations }}
       tolerations:
-{{ toYaml .Values.streamingNode.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
     {{- end }}
-    {{- if and (.Values.topologySpreadConstraints) (not .Values.streamingNode.topologySpreadConstraints) }}
+    {{- $topologySpreadConstraints := .Values.streamingNode.topologySpreadConstraints -}}
+    {{- if and .group .group.topologySpreadConstraints -}}
+    {{- $topologySpreadConstraints = .group.topologySpreadConstraints -}}
+    {{- end }}
+    {{- if and (.Values.topologySpreadConstraints) (not $topologySpreadConstraints) }}
       topologySpreadConstraints:
 {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
     {{- end }}
-    {{- if .Values.streamingNode.topologySpreadConstraints }}
+    {{- if $topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml .Values.streamingNode.topologySpreadConstraints | indent 8 }}
+{{ toYaml $topologySpreadConstraints | indent 8 }}
     {{- end }}
     {{- if and (.Values.securityContext) (not .Values.streamingNode.securityContext) }}
       securityContext:
@@ -232,12 +284,17 @@ spec:
 {{- end -}}
 
 {{- if and .Values.streaming .Values.streaming.enabled .Values.cluster.enabled }}
-{{- if .Values.replicaResourceGroups }}
+{{- if .Values.streamingNode.groups }}
+{{- range $group := .Values.streamingNode.groups }}
+---
+{{ include "milvus.streamingnode.deployment" (merge (dict "group" $group "rg" "") $) }}
+{{- end }}
+{{- else if .Values.replicaResourceGroups }}
 {{- range $rg := .Values.replicaResourceGroups }}
 ---
-{{ include "milvus.streamingnode.deployment" (merge (dict "rg" $rg) $) }}
+{{ include "milvus.streamingnode.deployment" (merge (dict "group" (dict) "rg" $rg) $) }}
 {{- end }}
 {{- else }}
-{{ include "milvus.streamingnode.deployment" (merge (dict "rg" "") .) }}
+{{ include "milvus.streamingnode.deployment" (merge (dict "group" (dict) "rg" "") .) }}
 {{- end }}
 {{- end }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -283,6 +283,10 @@ proxy:
   enabled: true
   # You can set the number of replicas to -1 to remove the replicas field in case you want to use HPA
   replicas: 1
+  # Optional deployment groups. When set, one Deployment is rendered per group.
+  # Group-level replicas, labels, annotations, extraEnv, nodeSelector, affinity,
+  # tolerations, and topologySpreadConstraints override or extend this component.
+  groups: []
   resources: {}
   nodeSelector: {}
   affinity: {}
@@ -387,6 +391,9 @@ queryNode:
   enabled: true
   # You can set the number of replicas to -1 to remove the replicas field in case you want to use HPA
   replicas: 1
+  # Optional deployment groups. When set, one Deployment is rendered per group.
+  # Use group.extraEnv to inject resource-group env vars when needed.
+  groups: []
   resources: {}
   # Set local storage size in resources
   # resources:
@@ -517,6 +524,8 @@ dataNode:
   enabled: true
   # You can set the number of replicas to -1 to remove the replicas field in case you want to use HPA
   replicas: 1
+  # Optional deployment groups. When set, one Deployment is rendered per group.
+  groups: []
   resources: {}
   nodeSelector: {}
   affinity: {}
@@ -545,6 +554,7 @@ mixCoordinator:
   enabled: true
   # You can set the number of replicas greater than 1, only if enable active standby
   replicas: 1           # Run Mixture Coordinator mode with replication disabled
+  labels: {}
   resources: {}
   nodeSelector: {}
   affinity: {}
@@ -571,6 +581,9 @@ mixCoordinator:
 
 streamingNode:
   replicas: 1
+  # Optional deployment groups. When set, one Deployment is rendered per group.
+  # Use group.extraEnv to inject resource-group env vars when needed.
+  groups: []
   resources: {}
   nodeSelector: {}
   affinity: {}

--- a/docs/deployment-groups-resource-group-guide.md
+++ b/docs/deployment-groups-resource-group-guide.md
@@ -1,0 +1,360 @@
+# Deployment Groups and Resource Group Guide
+
+## Overview
+
+Milvus Helm supports deployment groups for splitting selected Milvus components into multiple Kubernetes Deployments. A deployment group is a Kubernetes deployment unit. It can carry its own replica count, labels, annotations, environment variables, and scheduling rules.
+
+Deployment groups are independent from Milvus resource groups. If a group should join a Milvus resource group, inject the corresponding Milvus environment variable in that group and configure Milvus load settings explicitly.
+
+## Supported Components
+
+The following components support multiple deployment groups:
+
+- `proxy.groups`
+- `dataNode.groups`
+- `queryNode.groups`
+- `streamingNode.groups`
+
+`mixCoordinator` always renders a single Deployment. Use `mixCoordinator.labels`, `mixCoordinator.annotations`, and the normal scheduling fields to customize that Deployment.
+
+When groups are configured, each group renders one Deployment named with the group suffix, for example `my-release-milvus-proxy-az1`. Each group also gets the reserved selector label `milvus.io/deployment-group: <group-name>` so Deployment selectors do not overlap. Component Services keep selecting all pods for the component.
+
+## Group Fields
+
+Each group can use these fields for `proxy`, `dataNode`, `queryNode`, and `streamingNode`:
+
+```yaml
+name: az1
+replicas: 1
+labels: {}
+annotations: {}
+extraEnv: []
+nodeSelector: {}
+affinity: {}
+tolerations: []
+topologySpreadConstraints: []
+```
+
+`name` should be unique within the component. Group labels are added to the Deployment and pod template. Scheduling fields in a group override the component-level scheduling fields for that group. If a group does not set a scheduling field, the component-level value is used, then the global value is used.
+
+For `proxy`, `dataNode`, and `queryNode`, enabling HPA renders one HPA per group. Each HPA targets the Deployment for that group.
+
+## Split Components by AZ
+
+This example splits Proxy and DataNode by availability zone. Labels are user-defined and can follow your own naming scheme.
+
+```yaml
+proxy:
+  groups:
+    - name: az1
+      replicas: 1
+      labels:
+        topology.milvus.io/az: az1
+      nodeSelector:
+        topology.kubernetes.io/zone: us-east-1a
+    - name: az2
+      replicas: 1
+      labels:
+        topology.milvus.io/az: az2
+      nodeSelector:
+        topology.kubernetes.io/zone: us-east-1b
+
+dataNode:
+  groups:
+    - name: az1
+      replicas: 1
+      labels:
+        topology.milvus.io/az: az1
+      nodeSelector:
+        topology.kubernetes.io/zone: us-east-1a
+    - name: az2
+      replicas: 1
+      labels:
+        topology.milvus.io/az: az2
+      nodeSelector:
+        topology.kubernetes.io/zone: us-east-1b
+```
+
+## Split QueryNode and StreamingNode by Milvus Resource Group
+
+Milvus resource group membership is controlled by the `MILVUS_SERVER_LABEL_RESOURCE_GROUP` environment variable. The Helm group itself does not imply a Milvus resource group, and the group `replicas` value is only the Kubernetes pod count for that Deployment.
+
+```yaml
+queryNode:
+  groups:
+    - name: rg-a-az1
+      replicas: 1
+      labels:
+        topology.milvus.io/az: az1
+      nodeSelector:
+        topology.kubernetes.io/zone: us-east-1a
+      extraEnv:
+        - name: MILVUS_SERVER_LABEL_RESOURCE_GROUP
+          value: rg-a
+    - name: rg-b-az2
+      replicas: 1
+      labels:
+        topology.milvus.io/az: az2
+      nodeSelector:
+        topology.kubernetes.io/zone: us-east-1b
+      extraEnv:
+        - name: MILVUS_SERVER_LABEL_RESOURCE_GROUP
+          value: rg-b
+
+streamingNode:
+  groups:
+    - name: rg-a-az1
+      replicas: 1
+      labels:
+        topology.milvus.io/az: az1
+      nodeSelector:
+        topology.kubernetes.io/zone: us-east-1a
+      extraEnv:
+        - name: MILVUS_SERVER_LABEL_RESOURCE_GROUP
+          value: rg-a
+    - name: rg-b-az2
+      replicas: 1
+      labels:
+        topology.milvus.io/az: az2
+      nodeSelector:
+        topology.kubernetes.io/zone: us-east-1b
+      extraEnv:
+        - name: MILVUS_SERVER_LABEL_RESOURCE_GROUP
+          value: rg-b
+```
+
+## Configure Multi-Replica Serving
+
+Deployment groups and Milvus resource groups solve different parts of the serving plan.
+
+- AZ isolation is a Kubernetes scheduling concern. Use deployment groups, labels, and node selectors to place pods in different availability zones.
+- Resource group isolation is a Milvus serving concern. Use `MILVUS_SERVER_LABEL_RESOURCE_GROUP` to let QueryNode and StreamingNode join specific Milvus resource groups.
+- Replica management is a Milvus load concern. Use global Milvus load config to decide how many query replicas should exist and which resource groups should serve them.
+
+Do not use the Helm group `replicas` field as the Milvus query replica count. The Helm value only controls Kubernetes pod count for that Deployment.
+
+### Milvus Load Configs
+
+The procedures below use these Milvus configuration keys:
+
+| Key | Meaning |
+| --- | --- |
+| `queryCoord.clusterLevelLoadReplicaNumber` | Global query replica count. For example, `2` means Milvus should keep two query replicas by default at the cluster level. |
+| `queryCoord.clusterLevelLoadResourceGroups` | Comma-separated target Milvus resource groups for cluster-level load placement. The number of resource groups should be at least the configured replica count. |
+| `queryCoord.clusterLevelLoadForceOverrideUserReplicaMode` | When `true`, Milvus uses the global replica count and resource-group list as the cluster-level serving policy. Use this when the operator wants the global policy to be enforced consistently. |
+| `streaming.primaryResourceGroup` | Target resource group for WAL primary placement. When set, WAL operations use StreamingNodes in that resource group. |
+| `streaming.strictResourceGroupIsolation.enabled` | When `true`, StreamingNode assignment follows resource-group isolation strictly. If a replica resource group has no matching StreamingNode resource group, that replica will not receive a streaming query node assignment. |
+
+You can update these configs through the Milvus configuration management API. The management API is served from the MixCoord management port, usually `<mixcoord-host>:9091`. Use direct `etcdctl` writes only when the management endpoint is unavailable or your operation runbook already manages Milvus dynamic config through etcd.
+
+```bash
+curl -X POST http://<mixcoord-host>:9091/management/config/alter \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "configs": [
+      {"key": "queryCoord.clusterLevelLoadReplicaNumber", "value": "2"},
+      {"key": "queryCoord.clusterLevelLoadResourceGroups", "value": "rg-a,rg-b"},
+      {"key": "queryCoord.clusterLevelLoadForceOverrideUserReplicaMode", "value": "true"},
+      {"key": "streaming.primaryResourceGroup", "value": "rg-a"},
+      {"key": "streaming.strictResourceGroupIsolation.enabled", "value": "true"}
+    ]
+  }'
+```
+
+To inspect the current values:
+
+```bash
+curl 'http://<mixcoord-host>:9091/management/config/get?keys=queryCoord.clusterLevelLoadReplicaNumber,queryCoord.clusterLevelLoadResourceGroups,streaming.primaryResourceGroup'
+```
+
+Equivalent etcd writes:
+
+```bash
+ETCDCTL_API=3 etcdctl --endpoints=http://<etcd-endpoint>:2379 put \
+  by-dev/config/queryCoord.clusterLevelLoadReplicaNumber 2
+ETCDCTL_API=3 etcdctl --endpoints=http://<etcd-endpoint>:2379 put \
+  by-dev/config/queryCoord.clusterLevelLoadResourceGroups rg-a,rg-b
+ETCDCTL_API=3 etcdctl --endpoints=http://<etcd-endpoint>:2379 put \
+  by-dev/config/queryCoord.clusterLevelLoadForceOverrideUserReplicaMode true
+ETCDCTL_API=3 etcdctl --endpoints=http://<etcd-endpoint>:2379 put \
+  by-dev/config/streaming.primaryResourceGroup rg-a
+ETCDCTL_API=3 etcdctl --endpoints=http://<etcd-endpoint>:2379 put \
+  by-dev/config/streaming.strictResourceGroupIsolation.enabled true
+```
+
+### Step 1: Create AZ-Isolated Capacity
+
+Add deployment groups for the AZs that should host serving capacity.
+
+What happens: Helm renders separate Kubernetes Deployments. Each Deployment has its own scheduling rules, so Kubernetes can place the pods in the intended AZ. The global Milvus replica placement does not change yet.
+
+```yaml
+queryNode:
+  groups:
+    - name: rg-a-az1
+      replicas: 1
+      nodeSelector:
+        topology.kubernetes.io/zone: us-east-1a
+      extraEnv:
+        - name: MILVUS_SERVER_LABEL_RESOURCE_GROUP
+          value: rg-a
+    - name: rg-b-az2
+      replicas: 1
+      nodeSelector:
+        topology.kubernetes.io/zone: us-east-1b
+      extraEnv:
+        - name: MILVUS_SERVER_LABEL_RESOURCE_GROUP
+          value: rg-b
+```
+
+Configure `streamingNode.groups` with the same resource-group and AZ plan when StreamingNode also needs RG isolation.
+
+### Step 2: Apply the Helm Upgrade
+
+Apply the chart change that creates the deployment groups.
+
+What happens: Kubernetes creates or updates the component Deployments. QueryNode and StreamingNode pods start and register into the Milvus resource group declared by `MILVUS_SERVER_LABEL_RESOURCE_GROUP`. The current global Milvus load config remains unchanged until you update it.
+
+```bash
+helm upgrade <release> <chart> -n <namespace> -f user.yaml
+```
+
+### Step 3: Set the Default Multi-Replica Policy
+
+Set the desired global query replica count and the resource groups that should host those replicas.
+
+What happens: QueryCoord starts converging the global serving plan to the configured replica count and target resource groups. Streaming uses the configured primary resource group when strict RG isolation is enabled.
+
+```bash
+curl -X POST http://<mixcoord-host>:9091/management/config/alter \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "configs": [
+      {"key": "queryCoord.clusterLevelLoadReplicaNumber", "value": "2"},
+      {"key": "queryCoord.clusterLevelLoadResourceGroups", "value": "rg-a,rg-b"},
+      {"key": "queryCoord.clusterLevelLoadForceOverrideUserReplicaMode", "value": "true"},
+      {"key": "streaming.primaryResourceGroup", "value": "rg-a"},
+      {"key": "streaming.strictResourceGroupIsolation.enabled", "value": "true"}
+    ]
+  }'
+```
+
+### Step 4: Wait for Load-Config Compliance
+
+Check the compliance endpoint before treating the new serving plan as ready.
+
+What happens: Milvus reports whether the expected replica count, target resource groups, query visibility, shard serviceability, old-resource cleanup, and primary RG placement have converged.
+
+```bash
+curl http://<mixcoord-host>:9091/management/replica/loadconfig/compliance
+```
+
+### Step 5: Keep Replica Placement in Milvus
+
+Manage replica count and resource-group placement through Milvus load config instead of adding or removing Helm deployment groups.
+
+What happens: Helm continues to describe available Kubernetes capacity. Milvus remains responsible for the global replica count and target resource-group placement.
+
+## Per-Replica Upgrading
+
+Use this procedure when global multi-replica serving should move from old resource groups to new resource groups one replica at a time. The example starts with two serving replicas on `old_rg_a` and `old_rg_b`, then moves them to `new_rg_a` and `new_rg_b`.
+
+The rule is:
+
+- Expansion phase for one replica: prepare the new node resource with Helm, then increase the Milvus replica config by one, then wait for compliance.
+- Shrink phase for the same replica: decrease the Milvus replica config by one, then wait for compliance, then remove the old node resource with Helm.
+
+Repeat the expansion and shrink sequence for each replica pair.
+
+### Step 1: Confirm the Current State
+
+```bash
+curl 'http://<mixcoord-host>:9091/management/config/get?keys=queryCoord.clusterLevelLoadReplicaNumber,queryCoord.clusterLevelLoadResourceGroups,streaming.primaryResourceGroup'
+```
+
+Expected state:
+
+- `queryCoord.clusterLevelLoadReplicaNumber` is `2`.
+- `queryCoord.clusterLevelLoadResourceGroups` is `old_rg_a,old_rg_b`.
+- `streaming.primaryResourceGroup` points to the old primary group, for example `old_rg_a`.
+
+What happens: no serving state changes. This step only confirms the starting point before the upgrade.
+
+### Step 2: Add Capacity for `new_rg_a`
+
+Add the new QueryNode and StreamingNode deployment groups for `new_rg_a` in `user.yaml`, then apply the Helm upgrade.
+
+What happens: Kubernetes creates the new pods. The new pods register into `new_rg_a`, but Milvus does not place a serving replica there until the global load config includes `new_rg_a`.
+
+```bash
+helm upgrade <release> <chart> -n <namespace> -f user.yaml
+```
+
+### Step 3: Expand Milvus Replicas for `new_rg_a`
+
+Increase the global replica count from `2` to `3` and add `new_rg_a` to the target resource-group list.
+
+```bash
+curl -X POST http://<mixcoord-host>:9091/management/config/alter \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "configs": [
+      {"key": "queryCoord.clusterLevelLoadReplicaNumber", "value": "3"},
+      {"key": "queryCoord.clusterLevelLoadResourceGroups", "value": "old_rg_a,old_rg_b,new_rg_a"}
+    ]
+  }'
+```
+
+What happens: QueryCoord starts creating one additional serving replica on `new_rg_a`. The existing replicas on `old_rg_a` and `old_rg_b` remain available while the new replica is being prepared.
+
+### Step 4: Wait Until the Expanded State Is Ready
+
+```bash
+curl http://<mixcoord-host>:9091/management/replica/loadconfig/compliance
+```
+
+What happens: Milvus may report `NotReady` while the new replica is still loading or becoming serviceable. Continue polling this endpoint until it reports `Ready`. At this point `old_rg_a`, `old_rg_b`, and `new_rg_a` are serving according to the expanded config.
+
+### Step 5: Shrink Milvus Replicas Away from `old_rg_a`
+
+Reduce the global replica count back to `2` and remove `old_rg_a` from the target resource-group list.
+
+If `old_rg_a` is the current primary streaming group, update `streaming.primaryResourceGroup` in the same operation window.
+
+```bash
+curl -X POST http://<mixcoord-host>:9091/management/config/alter \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "configs": [
+      {"key": "streaming.primaryResourceGroup", "value": "new_rg_a"},
+      {"key": "queryCoord.clusterLevelLoadReplicaNumber", "value": "2"},
+      {"key": "queryCoord.clusterLevelLoadResourceGroups", "value": "old_rg_b,new_rg_a"}
+    ]
+  }'
+```
+
+What happens: Milvus starts releasing the serving replica on `old_rg_a` and converging to the `old_rg_b,new_rg_a` target. Kubernetes resources for `old_rg_a` are still present during this step.
+
+### Step 6: Wait Until the Shrunk State Is Ready
+
+```bash
+curl http://<mixcoord-host>:9091/management/replica/loadconfig/compliance
+```
+
+What happens: Milvus reports `Ready` after the target replica count is back to `2`, replicas are placed on `old_rg_b,new_rg_a`, query visibility is ready, shard leaders are serviceable, `old_rg_a` resources are drained, and the primary RG placement is ready when configured.
+
+### Step 7: Remove `old_rg_a` Capacity
+
+Remove the old QueryNode and StreamingNode deployment groups for `old_rg_a` from `user.yaml`, then apply the Helm upgrade.
+
+```bash
+helm upgrade <release> <chart> -n <namespace> -f user.yaml
+```
+
+What happens: Kubernetes removes the old pods for `old_rg_a`. The serving plan already excludes `old_rg_a`, so removing the old Deployments should not change Milvus replica placement.
+
+### Step 8: Repeat for `old_rg_b` and `new_rg_b`
+
+Use the same sequence to move the remaining replica from `old_rg_b` to `new_rg_b`: add `new_rg_b` capacity with Helm, expand the Milvus replica config by one and wait for compliance, shrink the config away from `old_rg_b` and wait for compliance, then remove `old_rg_b` capacity with Helm.
+
+What happens: only one replica pair is changed in each round. Existing serving replicas stay in place while the new replica becomes ready, and old node resources are removed only after Milvus no longer targets that old resource group.


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds generic deployment group support for selected Milvus components so operators can split workloads into multiple Kubernetes Deployments, for example by availability zone or other user-defined labels.

Changes included:
- Adds `groups` support for Proxy, DataNode, QueryNode, and StreamingNode.
- Keeps MixCoord as a single Deployment while allowing custom labels on that Deployment and its pods.
- Adds a reserved `milvus.io/deployment-group` selector label to avoid overlapping Deployment selectors.
- Supports group-level `replicas`, `labels`, `annotations`, `extraEnv`, `nodeSelector`, `affinity`, `tolerations`, and `topologySpreadConstraints`.
- Renders per-group HPAs for Proxy, DataNode, and QueryNode when HPA is enabled.
- Keeps the legacy `replicaResourceGroups` path compatible for QueryNode and StreamingNode.
- Documents deployment groups and how to inject Milvus resource-group env vars explicitly through `extraEnv`.

Validation:
- `helm lint charts/milvus`
- `helm template defaulttest charts/milvus`
- `helm template grouptest charts/milvus ... groups ...`
- `helm template legacytest charts/milvus --set replicaResourceGroups[0]=rg-a --set replicaResourceGroups[1]=rg-b`
- `helm template badtest charts/milvus --set proxy.groups[0].replicas=1` verified the missing group name error
- `git diff --check`

## Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
