### PR TITLE
[tei] fix: correct extraEnv and volumeMounts rendering

### DIFF
--- a/charts/tei/Chart.yaml
+++ b/charts/tei/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tei/templates/statefulset.yaml
+++ b/charts/tei/templates/statefulset.yaml
@@ -56,13 +56,13 @@ spec:
           {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.extraEnv }}
         env:
-          {{ toYaml .Values.extraEnv | indent 8 }}
+        {{- toYaml .Values.extraEnv | nindent 8 }}
         {{- end }}
         volumeMounts:
         - name: data-volume
           mountPath: {{ .Values.persistence.mountPath }}
         {{- if .Values.volumeMounts }}
-          {{ toYaml .Values.volumeMounts | indent 8 }}
+        {{- toYaml .Values.volumeMounts | nindent 8 }}
         {{- end }}
       volumes:
       {{- if not .Values.persistence.enabled }}


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes #235. The `extraEnv` and `volumeMounts` blocks in the tei chart's StatefulSet template were rendered using a combination of literal template indentation and the `indent` filter, which produced invalid YAML whenever either value was configured (e.g. `error converting YAML to JSON: yaml: line 51: did not find expected key`).

This switches both blocks to `toYaml | nindent`, so list items align with the chart's existing block-sequence style (same indent as `args`/`ports`).

Example, before:
```yaml
env:
          - name: FOO
          value: bar
```

After:
```yaml
env:
- name: FOO
  value: bar
```

## Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
