### PR TITLE
[tei] feat: add runtimeClassName option

### DIFF
--- a/charts/tei/Chart.yaml
+++ b/charts/tei/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tei/README.md
+++ b/charts/tei/README.md
@@ -58,6 +58,7 @@ nodeSelector: {}                     # Node selector
 affinity: {}                         # Affinity configuration
 tolerations: []                      # Tolerations
 topologySpreadConstraints: []        # Topology spread constraints
+runtimeClassName: ""                 # Pod runtime class, e.g. "nvidia" for GPU nodes
 extraEnv: []                         # Additional environment variables
 ```
 
@@ -71,6 +72,7 @@ modelId: "BAAI/bge-large-en-v1.5"
 image:
   repository: ghcr.io/huggingface/text-embeddings-inference
   tag: 1.6  # GPU version
+runtimeClassName: nvidia  # Required when the cluster schedules GPUs via a non-default runtime
 resources:
   limits:
     nvidia.com/gpu: 1  # Allocate 1 GPU

--- a/charts/tei/templates/statefulset.yaml
+++ b/charts/tei/templates/statefulset.yaml
@@ -35,6 +35,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "tei.serviceAccountName" . }}
+      {{- with .Values.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/tei/values.yaml
+++ b/charts/tei/values.yaml
@@ -68,6 +68,9 @@ nodeSelector: {}
 affinity: {}
 tolerations: []
 topologySpreadConstraints: []
+# RuntimeClass to use for the pod, e.g. "nvidia" when running the GPU image on nodes
+# with the NVIDIA device plugin. Leave empty to use the default runtime.
+runtimeClassName: ""
 extraEnv: []
 
 


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a `runtimeClassName` value to the tei chart so the pod can be scheduled with a non-default runtime, e.g. `nvidia` when running the GPU image on nodes with the NVIDIA device plugin (the default `runc` runtime cannot use GPUs on clusters without CDI).

```yaml
image:
  tag: 1.6 # GPU image
runtimeClassName: nvidia
resources:
  limits:
    nvidia.com/gpu: 1
```

This mirrors the `runtimeClassName` support already present in the milvus chart (`queryNode.runtimeClassName` / `indexNode.runtimeClassName`).

## Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
